### PR TITLE
Benchmark API signature (w/o PBRF)

### DIFF
--- a/dattri/datasets/utils.py
+++ b/dattri/datasets/utils.py
@@ -1,4 +1,7 @@
-"""This module contains some utils function to process datasets."""
+"""This module contains some utils functions to process datasets."""
+
+# ruff: noqa: ARG001, TCH002
+# TODO: Remove the above line after finishing the implementation of the functions.
 
 from __future__ import annotations
 
@@ -7,13 +10,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Tuple, Union
 
-    import numpy as np
-    import torch
+import numpy as np
+import torch
 
 
-def flip_label(label: Union[np.ndarray, torch.Tensor], # noqa: ARG001
-               label_space: Union[list, np.ndarray, torch.Tensor] = None, # noqa: ARG001
-               p: float = 0.1) -> Tuple[Union[np.ndarray, torch.Tensor], list]: # noqa: ARG001
+def flip_label(label: Union[np.ndarray, torch.Tensor],
+               label_space: Union[list, np.ndarray, torch.Tensor] = None,
+               p: float = 0.1) -> Tuple[Union[np.ndarray, torch.Tensor], list]:
     """Flip the label of the input label tensor with the probability `p`.
 
     The function will randomly select a new label from the `label_space` to replace

--- a/dattri/metrics/groundtruth.py
+++ b/dattri/metrics/groundtruth.py
@@ -1,4 +1,7 @@
-"""This module calculate the groundtruth values for the metrics."""
+"""This module provides helper functions to calculate ground truth values."""
+
+# ruff: noqa: ARG001, TCH002
+# TODO: Remove the above line after finishing the implementation of the functions.
 
 from __future__ import annotations
 
@@ -8,18 +11,18 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Tuple
 
-    import torch
+import torch
 
 
-def calculate_loo_groundtruth(target_func: Callable, # noqa: ARG001
-                              retrain_dir: str, # noqa: ARG001
-                              test_dataloader: torch.utils.data.DataLoader, # noqa: ARG001
+def calculate_loo_groundtruth(target_func: Callable,
+                              retrain_dir: str,
+                              test_dataloader: torch.utils.data.DataLoader,
                               ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Calculate the groundtruth values for the Leave-One-Out (LOO) metric.
 
-    The LOO groundtruth is directly calculated by calculate the target value difference
-    for each sample in the test dataloader on each model in the retrain directory.
-    The target value is calculated by the target function.
+    The LOO groundtruth is directly calculated by calculating the target value
+    difference for each sample in the test dataloader on each model in the
+    retrain directory. The target value is calculated by the target function.
 
     Args:
         target_func (Callable): The target function that takes a model and a dataloader
@@ -49,13 +52,13 @@ def calculate_loo_groundtruth(target_func: Callable, # noqa: ARG001
     return None
 
 
-def calculate_lds_groundtruth(target_func: Callable, # noqa: ARG001
-                              retrain_dir: str, # noqa: ARG001
-                              test_dataloader: torch.utils.data.DataLoader, # noqa: ARG001
+def calculate_lds_groundtruth(target_func: Callable,
+                              retrain_dir: str,
+                              test_dataloader: torch.utils.data.DataLoader,
                               ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Calculate the groundtruth values for the Linear Datamodeling Score (LDS) metric.
 
-    The LDS groundtruth is directly calculated by calculate the target value for each
+    The LDS groundtruth is directly calculated by calculating the target value for each
     sample in the test dataloader on each model in the retrain directory. The target
     value is calculated by the target function.
 

--- a/dattri/metrics/metrics.py
+++ b/dattri/metrics/metrics.py
@@ -1,5 +1,9 @@
 """This module evaluate the performance of the data attribution."""
 
+# ruff: noqa: ARG001, TCH002
+# TODO: Remove the above line after finishing the implementation of the functions.
+
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -7,12 +11,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Tuple
 
-    import torch
+import torch
 
 
-def lds(score: torch.Tensor, # noqa: ARG001
-        ground_truth: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor: # noqa: ARG001
+def lds(score: torch.Tensor,
+        ground_truth: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
     """Calculate the Linear Datamodeling Score (LDS) metric.
+
+    TODO: Add the LDS metric description.
 
     Args:
         score (torch.Tensor): The score tensor with the shape
@@ -31,12 +37,14 @@ def lds(score: torch.Tensor, # noqa: ARG001
     return None
 
 
-def loo_corr(score: torch.Tensor, # noqa: ARG001
-             ground_truth: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor: # noqa: ARG001
+def loo_corr(score: torch.Tensor,
+             ground_truth: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
     """Calculate the Leave-One-Out (LOO) correlation metric.
 
     The LOO correlation is calculated by pearson correlation between the score
     tensor and the groundtruth.
+
+    TODO: more detailed description.
 
     Args:
         score (torch.Tensor): The score tensor with the shape (num_train_samples,
@@ -54,10 +62,12 @@ def loo_corr(score: torch.Tensor, # noqa: ARG001
     return None
 
 
-def mislabel_detection_auc(score: torch.Tensor, # noqa: ARG001
-                           ground_truth: Tuple[torch.Tensor, torch.Tensor], # noqa: ARG001
+def mislabel_detection_auc(score: torch.Tensor,
+                           ground_truth: Tuple[torch.Tensor, torch.Tensor],
                            ) -> Tuple[float, Tuple[float, ...]]:
     """Calculate the AUC using sorting algorithm.
+
+    TODO: more detailed description.
 
     Args:
         score (torch.Tensor): The self-attribution scores of shape (num_train_samples,).

--- a/dattri/model_utils/retrain.py
+++ b/dattri/model_utils/retrain.py
@@ -1,5 +1,9 @@
 """This module contains functions that retrain model for LOO/LDS/PBRF metrics."""
 
+# ruff: noqa: ARG001, TCH002
+# TODO: Remove the above line after finishing the implementation of the functions.
+
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -8,14 +12,14 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import List, Optional
 
-    import torch
+import torch
 
 
-def retrain_loo(train_func: Callable, # noqa: ARG001
-                dataloader: torch.utils.data.DataLoader, # noqa: ARG001
-                path: str, # noqa: ARG001
-                indices: Optional[List[int]] = None, # noqa: ARG001
-                seed: Optional[int] = None) -> None: # noqa: ARG001
+def retrain_loo(train_func: Callable,
+                dataloader: torch.utils.data.DataLoader,
+                path: str,
+                indices: Optional[List[int]] = None,
+                seed: Optional[int] = None) -> None:
     """Retrain the model for Leave-One-Out (LOO) metric.
 
     The retrained model checkpoints and the removed index metadata are saved
@@ -76,13 +80,13 @@ def retrain_loo(train_func: Callable, # noqa: ARG001
     """
     return
 
-def retrain_lds(train_func: Callable, # noqa: ARG001, PLR0913
-                dataloader: torch.utils.data.DataLoader, # noqa: ARG001
-                path: str, # noqa: ARG001
-                subset_number: int = 100, # noqa: ARG001
-                subset_ratio: float = 0.1, # noqa: ARG001
-                subset_average_run: int = 1, # noqa: ARG001
-                seed: Optional[int] = None) -> None: # noqa: ARG001
+def retrain_lds(train_func: Callable,  # noqa: PLR0913
+                dataloader: torch.utils.data.DataLoader,
+                path: str,
+                subset_number: int = 100,
+                subset_ratio: float = 0.1,
+                subset_average_run: int = 1,
+                seed: Optional[int] = None) -> None:
     """Retrain the model for Linear Datamodeling Score (LDS) metric.
 
     The retrained model checkpoints and the subset index metadata are saved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">=3.8"
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["ANN002", "D203", "D213", "D407", "UP"]  # ignores: ANN002 (unnecessarily strict rule), D203 (conflict with D211), D213 (conflict with D212), D407 (supporting Google style docstrings), UP (compatibility with Python 3.8)
+ignore = ["ANN002", "D203", "D213", "D407", "UP", "TD002", "TD003", "FIX002"]  # ignores: ANN002 (unnecessarily strict rule), D203 (conflict with D211), D213 (conflict with D212), D407 (supporting Google style docstrings), UP (compatibility with Python 3.8), TD002 (Missing author in TODO), TD003 (Missing issue link), FIX002 (TODO needs to be fixed)
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["E401", "E402"]


### PR DESCRIPTION
Work in progress, will add detailed information and request review soon.

# API overview
We add functions in three groups.

## retain generation
These 2 functions will train models with different subset. They don't return anything, and just save the retained model weight to a structured directory (defined carefully in docstring).
```python
# dattri/model_utils/retrain.py
retrain_loo(train_func: Callable,
            dataloader: torch.utils.data.DataLoader,
            path: str,
            indices: Optional[List[int]] = None,
            seed: Optional[int] = None) -> None:

retrain_lds(train_func: Callable,
            dataloader: torch.utils.data.DataLoader,
            path: str,
            subset_number: int = 100,
            subset_ratio: float = 0.1,
            subset_average_run: int = 1,
            seed: Optional[int] = None) -> None:
```

## groundtruth generation
These 3 functions will generate the groundtruth for metrics.
```python
# dattri/datasets/utils.py
flip_label(label: Union[np.ndarray, torch.Tensor],
           label_space: Union[list, np.ndarray, torch.Tensor] = None,
           p: float = 0.1) -> Tuple[Union[np.ndarray, torch.Tensor], list]:

# dattri/metrics/groundtruth.py
calculate_loo_groundtruth(target_func: Callable,
                          retrain_dir: str,
                          test_dataloader: torch.utils.data.DataLoader,
                          ) -> Tuple[torch.Tensor, torch.Tensor]:
calculate_lds_groundtruth(target_func: Callable,
                      retrain_dir: str,
                      test_dataloader: torch.utils.data.DataLoader,
                      ) -> Tuple[torch.Tensor, torch.Tensor]:
```

## metrics
These 3 functions will calculate the metrics with groundtruth and scores
```python
lds(score: torch.Tensor,
    ground_truth: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
loo_corr(score: torch.Tensor,
         ground_truth: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
mislabel_detection_auc(score: torch.Tensor,
                           ground_truth: Tuple[torch.Tensor, torch.Tensor],
                           ) -> Tuple[float, Tuple[float, ...]]:
```

# TODO
- PBRF need a core function `pbrf`, we should first implement this loss function and then design `retrain_pbrf` and `cal_pbrf_groundtruth` and `pbrf_corr`.