### PR TITLE
Allow additional package (`fast_jl`) installation in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ def setup_package():
         "url": "https://github.com/TRAIS-Lab/dattri",
         "packages": find_packages(),
         "install_requires": [],
+        "extras_require": {
+            'all': ['fast_jl']
+        },
         "include_package_data": True,
         "classifiers": [
             "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Users can additionally install `fast_jl` if they `pip install dattri[all]`.