### PR TITLE
Change ruff check rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
         pip install ruff
     - name: Analysing the code with ruff
       run: |
-        ruff check dattri
-        ruff check test
+        ruff check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,11 @@
 name = "dattri"
 requires-python = ">=3.8"
 
+[tool.ruff]
+exclude = [
+    "docs/"
+]
+
 [tool.ruff.lint]
 preview = true
 select = ["ALL"]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Setup."""
+
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -25,14 +26,15 @@ def setup_package():
         "packages": find_packages(),
         "install_requires": [],
         "extras_require": {
-            'all': ['fast_jl']
+            "all": ["fast_jl"],
         },
         "include_package_data": True,
         "classifiers": [
             "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: Implementation :: CPython"],
+            "Programming Language :: Python :: Implementation :: CPython",
+        ],
         "platforms": ["mac", "linux", "windows"],
     }
 


### PR DESCRIPTION
## Description

Previously ruff only checks the folders `dattri` and `test`, leading to format issues in `setup.py` uncaught. This PR changes `lint.yml` to make ruff by default check everything. Files that do not need ruff check should be listed in the `exclude` list in `pyproject.toml`. The folder `docs` is listed there now.