### PR TITLE
fix some missing parts in mnist_lr retrain func

### DIFF
--- a/dattri/benchmark/mnist.py
+++ b/dattri/benchmark/mnist.py
@@ -1,10 +1,12 @@
 """This module contains functions for model training/evaluation on the MNIST dataset."""
+
 import torch
 from torch import nn
 
 
 class LogisticRegressionMnist(nn.Module):
     """A simple logistic regression model for MNIST dataset."""
+
     def __init__(self) -> None:
         """Initialize the logistic regression model."""
         super(LogisticRegressionMnist, self).__init__()
@@ -23,11 +25,15 @@ class LogisticRegressionMnist(nn.Module):
         return self.linear(x)
 
 
-def train_mnist_lr(dataloader: torch.utils.data.DataLoader) -> LogisticRegressionMnist:
+def train_mnist_lr(
+    dataloader: torch.utils.data.DataLoader,
+    device: str = "cuda",
+) -> LogisticRegressionMnist:
     """Train a logistic regression model on the MNIST dataset.
 
     Args:
         dataloader: The dataloader for the MNIST dataset.
+        device: The device to train the model on.
 
     Returns:
         The trained logistic regression model.
@@ -37,22 +43,30 @@ def train_mnist_lr(dataloader: torch.utils.data.DataLoader) -> LogisticRegressio
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
     model.train()
-    for inputs, labels in dataloader:
-        optimizer.zero_grad()
-        outputs = model(inputs)
-        loss = criterion(outputs, labels)
-        loss.backward()
-        optimizer.step()
+    model.to(device)
+    epoch_num = 20
+    for _ in range(epoch_num):
+        for inputs, labels in dataloader:
+            optimizer.zero_grad()
+            outputs = model(inputs.to(device))
+            loss = criterion(outputs, labels.to(device))
+            loss.backward()
+            optimizer.step()
 
     return model
 
 
-def loss_mnist_lr(model: nn.Module, dataloader: torch.utils.data.DataLoader) -> float:
+def loss_mnist_lr(
+    model: nn.Module,
+    dataloader: torch.utils.data.DataLoader,
+    device: str = "cuda",
+) -> float:
     """Calculate the loss of the logistic regression model on the MNIST dataset.
 
     Args:
         model: The logistic regression model.
         dataloader: The dataloader for the MNIST dataset.
+        device: The device to evaluate the model on.
 
     Returns:
         The sum of loss of the model on the loader.
@@ -63,8 +77,8 @@ def loss_mnist_lr(model: nn.Module, dataloader: torch.utils.data.DataLoader) -> 
     total_samples = 0
     with torch.no_grad():
         for inputs, labels in dataloader:
-            outputs = model(inputs)
-            loss = criterion(outputs, labels)
+            outputs = model(inputs.to(device))
+            loss = criterion(outputs, labels.to(device))
             total_loss += loss.item() * inputs.shape[0]
             total_samples += inputs.shape[0]
     return total_loss / total_samples

--- a/test/dattri/datasets/test_mnist.py
+++ b/test/dattri/datasets/test_mnist.py
@@ -1,4 +1,5 @@
 """Test mnist functions."""
+
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -24,11 +25,11 @@ class TestMnist:
 
     def test_train_mnist_lr(self):
         """Test train_mnist_lr."""
-        model = train_mnist_lr(self.train_dataloader)
+        model = train_mnist_lr(self.train_dataloader, device="cpu")
         assert isinstance(model, LogisticRegressionMnist)
 
     def test_loss_mnist_lr(self):
         """Test loss_mnist_lr."""
-        model = train_mnist_lr(self.train_dataloader)
-        loss = loss_mnist_lr(model, self.test_dataloader)
+        model = train_mnist_lr(self.train_dataloader, device="cpu")
+        loss = loss_mnist_lr(model, self.test_dataloader, device="cpu")
         assert isinstance(loss, float)


### PR DESCRIPTION
## Description

### 1. Motivation and Context
This PR is used to fix some minor issue in mnist + lr retrain/loss calculation functions.

### 2. Summary of the change
1. Make the training epoch to 20 epochs, this will bring 90% test accuracy (previous 1 epoch seems too small)
2. add a `device` parameter to the functions, so that users could choose which device to run the retraining/evaluation.

### 3. What tests have been added/updated for the change?
- [ ] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
