### PR TITLE
[dattri.benchmark] Fix output format of maestro dataset creation

### DIFF
--- a/dattri/benchmark/datasets/maestro/data.py
+++ b/dattri/benchmark/datasets/maestro/data.py
@@ -27,7 +27,7 @@ FULL_VERSION = True  # State if the whole dataset will be transversed.
 def create_maestro_datasets(
     dataset_path: str,
 ) -> Tuple[Dataset, Dataset, Dataset]:
-    """Create training, validation, and testing datasets for MAESTRO dataset.
+    """Create MAESTRO dataset.
 
     Args:
         dataset_path (str): Root directory of the MAESTRO Dataset. Should be


### PR DESCRIPTION
## Description
This PR fix the output format of the `create_maestro_datasets` function.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context
Originally, the `dattri/benchmark/maestro/data/create_maestro_datasets` function will directly output three dataloaders. But I found that the current `dattri/scripts/dattri_retrain.py` actually will assume this function to output torch dataset objects (will construct data loaders in that script). Thus make this change.
<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

### 2. Summary of the change
- fix the output format of create_maestro_datasets
- remove redundant data loader construction codes
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

