### PR TITLE
[dattri.model_utils] Add tfidf sampler

### DIFF
--- a/dattri/model_utils/tfidf_sampler.py
+++ b/dattri/model_utils/tfidf_sampler.py
@@ -1,0 +1,97 @@
+"""TF-IDF Subset Sampler Module.
+
+This module provides function called tfidf_subset_sampler
+to sample subsets based on TF-IDF similarity and save the filterd train data
+and return the indices of orignial train set.
+The indices in return value represent the indices of blocks.
+"""
+
+# ruff: noqa: S301, S403
+
+import pickle
+from pathlib import Path
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+def load_data(data_path: str) -> tuple:
+    """Load metadata, training, and validation data."""
+    data_path = Path(data_path)
+    meta_path = data_path / "meta.pkl"
+    train_bin_path = data_path / "train.bin"
+    val_bin_path = data_path / "val.bin"
+
+    with meta_path.open("rb") as f:
+        meta = pickle.load(f)
+        if not isinstance(meta, dict) or "itos" not in meta or "stoi" not in meta:
+            error = "Invalid metadata format"
+            raise ValueError(error)
+
+    encoded_train_data = np.fromfile(train_bin_path, dtype=np.uint16)
+    encoded_val_data = np.fromfile(val_bin_path, dtype=np.uint16)
+
+    return meta, encoded_train_data, encoded_val_data
+
+
+def decode_data(encoded_data: np.ndarray, itos: dict) -> str:
+    """Decode the encoded data using the provided itos mapping."""
+    return "".join(itos[i] for i in encoded_data)
+
+
+def split_blocks(data: str, block_size: int) -> list:
+    """Split data into blocks of specified size."""
+    return [data[i:i + block_size]
+        for i in range(0, len(data) - block_size, block_size)]
+
+
+def compute_similarity(train_blocks: list, val_block: str, subset_num: int) -> tuple:
+    """Compute cosine similarity between train blocks and a validation block."""
+    vectorizer = TfidfVectorizer()
+    train_tfidf_matrix = vectorizer.fit_transform(train_blocks)
+    val_tfidf = vectorizer.transform([val_block])
+    cos_sim = cosine_similarity(val_tfidf, train_tfidf_matrix)
+    selected_indices = np.argsort(-cos_sim[0])[:subset_num]
+    return selected_indices, train_blocks
+
+
+def tfidf_subset_sampler(data_path: str,
+                         val_block_position: int,
+                         block_size: int,
+                         subset_num: int) -> list:
+    """Sample a subset of TF-IDF blocks based on similarity and save to given path.
+
+    Args:
+        data_path (str): path to directory containing and to save the data files.
+        val_block_position (int): Position index of the validation block.
+        block_size (int): Size of each text block.
+        subset_num (int): Number of top similar blocks to return.
+    """
+    meta, encoded_train_data, encoded_val_data = load_data(data_path)
+    itos = meta["itos"]
+    stoi = meta["stoi"]
+
+    decoded_train_data = decode_data(encoded_train_data, itos)
+    decoded_val_data = decode_data(encoded_val_data, itos)
+
+    train_blocks = split_blocks(decoded_train_data, block_size)
+    val_blocks = split_blocks(decoded_val_data, block_size)
+
+    val_block = val_blocks[val_block_position]
+
+    selected_indices, train_blocks = compute_similarity(train_blocks,
+                                                        val_block,
+                                                        subset_num)
+    similar_train_blocks = [train_blocks[i] for i in selected_indices]
+
+    output_bin_path = Path(data_path) / "filtered_train.bin"
+    reencoded_chars = [
+        stoi[char]
+        for block in similar_train_blocks
+        for char in block
+    ]
+    filtered_train_data = np.array(reencoded_chars, dtype=np.uint16)
+    filtered_train_data.tofile(output_bin_path)
+
+    return selected_indices

--- a/dattri/model_utils/tfidf_sampler.py
+++ b/dattri/model_utils/tfidf_sampler.py
@@ -1,9 +1,8 @@
 """TF-IDF Subset Sampler Module.
 
-This module provides function called tfidf_subset_sampler
-to sample subsets based on TF-IDF similarity and save the filterd train data
-and return the indices of orignial train set.
-The indices in return value represent the indices of blocks.
+This module provides functions to sample subsets based on TF-IDF similarity,
+save the filtered train data, and return the indices of the original train set.
+The indices in the return value represent the indices of blocks.
 """
 
 # ruff: noqa: S301, S403
@@ -17,7 +16,18 @@ from sklearn.metrics.pairwise import cosine_similarity
 
 
 def load_data(data_path: str) -> tuple:
-    """Load metadata, training, and validation data."""
+    """Load metadata, training, and validation data.
+
+    Args:
+        data_path (str): Path to the data directory.
+
+    Returns:
+        tuple: A tuple containing metadata (dict), encoded training data (np.ndarray),
+               and encoded validation data (np.ndarray).
+
+    Raises:
+        ValueError: If the metadata is not in the expected format.
+    """
     data_path = Path(data_path)
     meta_path = data_path / "meta.pkl"
     train_bin_path = data_path / "train.bin"
@@ -36,18 +46,43 @@ def load_data(data_path: str) -> tuple:
 
 
 def decode_data(encoded_data: np.ndarray, itos: dict) -> str:
-    """Decode the encoded data using the provided itos mapping."""
+    """Decode the encoded data using the provided itos mapping.
+
+    Args:
+        encoded_data (np.ndarray): The encoded data array.
+        itos (dict): A dictionary mapping indices to characters.
+
+    Returns:
+        str: The decoded string.
+    """
     return "".join(itos[i] for i in encoded_data)
 
 
 def split_blocks(data: str, block_size: int) -> list:
-    """Split data into blocks of specified size."""
+    """Split data into blocks of specified size.
+
+    Args:
+        data (str): The input data string.
+        block_size (int): The size of each block.
+
+    Returns:
+        list: A list of data blocks.
+    """
     return [data[i:i + block_size]
         for i in range(0, len(data) - block_size, block_size)]
 
 
 def compute_similarity(train_blocks: list, val_block: str, subset_num: int) -> tuple:
-    """Compute cosine similarity between train blocks and a validation block."""
+    """Compute cosine similarity between train blocks and a validation block.
+
+    Args:
+        train_blocks (list): A list of training data blocks.
+        val_block (str): The validation data block.
+        subset_num (int): The number of top similar blocks to return.
+
+    Returns:
+        tuple: A tuple containing the selected indices and the training blocks.
+    """
     vectorizer = TfidfVectorizer()
     train_tfidf_matrix = vectorizer.fit_transform(train_blocks)
     val_tfidf = vectorizer.transform([val_block])
@@ -67,6 +102,9 @@ def tfidf_subset_sampler(data_path: str,
         val_block_position (int): Position index of the validation block.
         block_size (int): Size of each text block.
         subset_num (int): Number of top similar blocks to return.
+
+    Returns:
+        list: A list of indices representing the selected similar training blocks.
     """
     meta, encoded_train_data, encoded_val_data = load_data(data_path)
     itos = meta["itos"]


### PR DESCRIPTION
## Description

This module provides function called tfidf_subset_sampler to sample subsets based on TF-IDF similarity and save the filterd train data and return the indices of orignial train set. It is designed for benchmark nanoGPT.

### 1. Motivation and Context

To solve the problem in  issue #73.

### 2. Summary of the change

Add a new file called tfidf_sampler.py under model_utils. The callable function tfidf_subset_sampler is included in it

### 3. What tests have been added/updated for the change?
- [ ] N/A: No test will be added 

