### PR TITLE
[dattri] fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,8 @@ homepage = "https://github.com/TRAIS-Lab/dattri"
 fast = ["fast_jl"]
 test = ["build", "pytest", "pre-commit", "ruff", "darglint", "scikit-learn", "pretty_midi", "requests"]
 
-[tool.setuptools]
-packages = ["dattri"]
-include-package-data = true
+[tool.setuptools.packages]
+find = {}
 
 [project.entry-points.console_scripts]
 dattri_retrain="dattri.scripts.dattri_retrain:main"


### PR DESCRIPTION
## Description
This is a small fix. Currently our setup.py does not package the whl package correctly

`python setup.py bdist_wheel` will only package an empty whl file.