### PR TITLE
[dattri.algorithm] Add `AttributionTask` abstraction for new API design

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,8 +16,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        pip uninstall -y dattri
         python -m pip install --upgrade pip
-        pip install -e .[test,full]
+        pip install -e .[test]
     - name: Analysing the code with pytest
       run: |
         pytest -v test

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -47,17 +47,29 @@ class BaseInnerProductAttributor(BaseAttributor):
         self.index = 0
 
     def _set_test_data(self, dataloader: torch.utils.data.DataLoader) -> None:
-        """Set test dataloader."""
+        """Set test dataloader.
+
+        Args:
+            dataloader (DataLoader): The dataloader for test samples to be attributed.
+        """
         # This function may be overrided by the subclass
         self.test_dataloader = dataloader
 
     def _set_train_data(self, dataloader: torch.utils.data.DataLoader) -> None:
-        """Set train dataloader to be attributed."""
+        """Set train dataloader to be attributed.
+
+        Args:
+            dataloader (DataLoader): The dataloader for train samples to be attributed.
+        """
         # This function may be overrided by the subclass
         self.train_dataloader = dataloader
 
     def _set_full_train_data(self, dataloader: torch.utils.data.DataLoader) -> None:
-        """Set train dataloader for full training set."""
+        """Set train dataloader for full training set.
+
+        Args:
+            dataloader (DataLoader): The dataloader for full training samples.
+        """
         # This function may be overrided by the subclass
         self.full_train_dataloader = dataloader
 

--- a/dattri/func/ihvp.py
+++ b/dattri/func/ihvp.py
@@ -795,7 +795,7 @@ def ihvp_datainf(
     if regularization is not None and not isinstance(regularization, list):
         regularization = [regularization] * len(param_layer_map)
 
-    if len(regularization) != len(param_layer_map):
+    if ihvp_datainf is not None and len(regularization) != len(param_layer_map):
         error_msg = "The length of regularization should\
                      be the same as the number of layers."
         raise IHVPUsageError(error_msg)

--- a/dattri/func/ihvp.py
+++ b/dattri/func/ihvp.py
@@ -795,7 +795,7 @@ def ihvp_datainf(
     if regularization is not None and not isinstance(regularization, list):
         regularization = [regularization] * len(param_layer_map)
 
-    if ihvp_datainf is not None and len(regularization) != len(param_layer_map):
+    if param_layer_map is not None and len(regularization) != len(param_layer_map):
         error_msg = "The length of regularization should\
                      be the same as the number of layers."
         raise IHVPUsageError(error_msg)

--- a/dattri/func/ihvp.py
+++ b/dattri/func/ihvp.py
@@ -746,7 +746,7 @@ def ihvp_datainf(
     func: Callable,
     argnums: int,
     in_dims: Tuple[Union[None, int], ...],
-    regularization: Optional[List[float]] = None,
+    regularization: Optional[Union[float, List[float]]] = None,
     param_layer_map: Optional[List[int]] = None,
 ) -> Callable:
     """DataInf ihvp algorithm function.
@@ -768,12 +768,14 @@ def ihvp_datainf(
         in_dims (Tuple[Union[None, int], ...]): Parameter sent to vmap to produce
             batched layer-wise gradients. Example: inputs, weights, labels corresponds
             to (0,None,0).
-        regularization (List [float]): A list of floats default to 0.0. Specifies the
+        regularization (List [float]): A float or list of floats default to 0.0.
+            Specifies the
             regularization term to be added to the Hessian matrix in each layer.
             This is useful when the Hessian matrix is singular or ill-conditioned.
             The regularization term is `regularization * I`, where `I` is the
             identity matrix directly added to the Hessian matrix. The list is
             of length L, where L is the total number of layers.
+        TODO: param_layer_map should not be optional.
         param_layer_map: Optional[List[int]]: Specifies how the parameters are grouped
             into layers. Should be the same length as parameters tuple. For example,
             for a two layer model, params = (0.weights1,0.bias,1.weights,1.bias),
@@ -785,15 +787,20 @@ def ihvp_datainf(
         `func` and `v`.
     """
     batch_grad_func = vmap(grad(func, argnums=argnums), in_dims=in_dims)
+    if regularization is not None and not isinstance(regularization, list):
+        regularization = [regularization] * len(param_layer_map)
 
-    def _single_datainf_ihvp(v: torch.Tensor,
-                             grad: torch.Tensor,
-                             regularization: float) -> torch.Tensor:
-        coef = (v.T @ grad) / (regularization + torch.sum(grad ** 2))
-        return (v - coef * grad) / regularization
+    def _single_datainf_ihvp(
+        v: torch.Tensor,
+        grad: torch.Tensor,
+        regularization: float,
+    ) -> torch.Tensor:
+        coef = (v @ grad) / (regularization + torch.sum(grad**2))
+        return (v - coef.reshape(-1, 1) @ grad.reshape(1, -1)) / regularization
 
     def _ihvp_datainf_func(
-        x: Tuple[torch.Tensor, ...], v: Tuple[torch.Tensor, ...],
+        x: Tuple[torch.Tensor, ...],
+        v: Tuple[torch.Tensor, ...],
     ) -> Tuple[torch.Tensor]:
         """The IHVP function using CG.
 
@@ -813,9 +820,13 @@ def ihvp_datainf(
             grouped = []
             max_layer = max(param_layer_map)
             for group in range(max_layer + 1):
-                grouped_layers = tuple([grads[layer] for layer in
-                                        range(len(param_layer_map))
-                                        if param_layer_map[layer] == group])
+                grouped_layers = tuple(
+                    [
+                        grads[layer]
+                        for layer in range(len(param_layer_map))
+                        if param_layer_map[layer] == group
+                    ],
+                )
                 concated_grads = torch.concat(grouped_layers, dim=1)
                 grouped.append(concated_grads)
             grads = tuple(grouped)
@@ -824,13 +835,17 @@ def ihvp_datainf(
         for layer in range(layer_cnt):
             grad_layer = grads[layer]
             reg = 0.0 if regularization is None else regularization[layer]
-            ihvp_contributions = vmap(lambda grad, layer=layer, reg=reg:
-                                                 _single_datainf_ihvp(v[layer],
-                                                                      grad,
-                                                                      reg))(grad_layer)
+            ihvp_contributions = vmap(
+                lambda grad, layer=layer, reg=reg: _single_datainf_ihvp(
+                    v[layer],
+                    grad,
+                    reg,
+                ),
+            )(grad_layer)
             ihvp_at_layer = ihvp_contributions.mean(dim=0)
             ihvps.append(ihvp_at_layer)
         return tuple(ihvps)
+
     return _ihvp_datainf_func
 
 
@@ -877,29 +892,38 @@ def ihvp_at_x_datainf(
         A function that takes a tuple `v` and returns the tuple of IHVPs of the Hessian
         of `func` and `v`.
     """
+
     def _per_sample_grad(*args) -> torch.Tensor:
         return grad(func, argnums=argnums)(*args)
 
-    def _single_datainf_ihvp(v: torch.Tensor,
-                                     grad: torch.Tensor,
-                                     regularization: float) -> torch.Tensor:
-        coef = (v.T @ grad) / (regularization + torch.sum(grad ** 2))
+    def _single_datainf_ihvp(
+        v: torch.Tensor,
+        grad: torch.Tensor,
+        regularization: float,
+    ) -> torch.Tensor:
+        coef = (v.T @ grad) / (regularization + torch.sum(grad**2))
         return (v - coef * grad) / regularization
+
     grads = vmap(_per_sample_grad, in_dims=in_dims)(*x)
     layer_cnt = len(grads)
     if param_layer_map is not None:
         grouped = []
         max_layer = max(param_layer_map)
         for group in range(max_layer + 1):
-            grouped_layers = tuple([grads[layer] for layer
-                                    in range(len(param_layer_map))
-                                    if param_layer_map[layer] == group])
+            grouped_layers = tuple(
+                [
+                    grads[layer]
+                    for layer in range(len(param_layer_map))
+                    if param_layer_map[layer] == group
+                ],
+            )
             concated_grads = torch.concat(grouped_layers, dim=1)
             grouped.append(concated_grads)
         grads = tuple(grouped)
         layer_cnt = max_layer + 1  # Assuming count starts from 0
 
-    def _ihvp_at_x_datainf_func(v: Tuple[torch.Tensor, ...],
+    def _ihvp_at_x_datainf_func(
+        v: Tuple[torch.Tensor, ...],
     ) -> Tuple[torch.Tensor]:
         """The IHVP function using datainf.
 
@@ -915,10 +939,13 @@ def ihvp_at_x_datainf(
         for layer in range(layer_cnt):
             reg = 0.0 if regularization is None else regularization[layer]
             grad_layer = grads[layer]
-            ihvp_contributions = vmap(lambda grad, layer=layer, reg=reg:
-                                                 _single_datainf_ihvp(v[layer],
-                                                                      grad,
-                                                                      regularization=reg))(grad_layer)
+            ihvp_contributions = vmap(
+                lambda grad, layer=layer, reg=reg: _single_datainf_ihvp(
+                    v[layer],
+                    grad,
+                    regularization=reg,
+                ),
+            )(grad_layer)
             ihvp_at_layer = ihvp_contributions.mean(dim=0)
             ihvps.append(ihvp_at_layer)
         return tuple(ihvps)
@@ -1215,6 +1242,7 @@ def manual_cache_forward(forward_func: Callable) -> Callable:
             cache.input_hidden_pairs.append((x1, y1))
             return y1
     """
+
     @wraps(forward_func)
     def cached_forward(self: torch.nn.Module, *args, **kwrds) -> torch.Tensor:
         if not hasattr(self, EKFAC_CACHE_KEY):
@@ -1225,11 +1253,13 @@ def manual_cache_forward(forward_func: Callable) -> Callable:
         cache.check_type()
         cache.retain_grad()
         return outputs
+
     return cached_forward
 
 
 class MLPCache:
     """Cache of input and output variables in a MLP layer."""
+
     input_hidden_pairs: ClassVar[List[Tuple[torch.Tensor, ...]]] = []
 
     def clear(self) -> None:
@@ -1257,18 +1287,22 @@ class MLPCache:
             IHVPUsageError: if any type of cached varibales is not torch.Tensor.
         """
         for inputs, hiddens in self.input_hidden_pairs:
-            if not (isinstance(inputs, torch.Tensor) and
-                    isinstance(hiddens, torch.Tensor)):
-                message = ("Incorrect type of variable is cached in `MLPCache`. "
-                           "Only `torch.Tensor` is supported.")
+            if not (
+                isinstance(inputs, torch.Tensor) and isinstance(hiddens, torch.Tensor)
+            ):
+                message = (
+                    "Incorrect type of variable is cached in `MLPCache`. "
+                    "Only `torch.Tensor` is supported."
+                )
                 raise IHVPUsageError(message)
 
 
-def _random_batch_iterator(*x,
-                           num_samples: int,
-                           in_dims: Optional[Tuple] = None,
-                           batch_size: int = 1,
-                           ) -> Generator[Tuple[torch.Tensor, ...], None, None]:
+def _random_batch_iterator(
+    *x,
+    num_samples: int,
+    in_dims: Optional[Tuple] = None,
+    batch_size: int = 1,
+) -> Generator[Tuple[torch.Tensor, ...], None, None]:
     """Randomly sample a batch of `batch_size` from the input data, without replacement.
 
        This iterator basically does the same thing as `torch.utils.data.DataLoader`,
@@ -1292,8 +1326,10 @@ def _random_batch_iterator(*x,
     """
     if batch_size > num_samples:
         batch_size = num_samples
-        message = ("`batch_size` is larger than total number of samples. "
-                   "Use `num_Samples` instead.")
+        message = (
+            "`batch_size` is larger than total number of samples. "
+            "Use `num_Samples` instead."
+        )
         warnings.warn(message, stacklevel=2)
 
     if in_dims is None:
@@ -1305,18 +1341,21 @@ def _random_batch_iterator(*x,
         # Randomly sample and collate a batch
         begin_idx = i * batch_size
         end_idx = min(num_samples, (i + 1) * batch_size)
-        sampled_indices = random_perm[begin_idx: end_idx]
+        sampled_indices = random_perm[begin_idx:end_idx]
         yield tuple(
             x_in.index_select(dim, sampled_indices.to(x_in.device))
-            if dim is not None else x_in
+            if dim is not None
+            else x_in
             for x_in, dim in zip(x, in_dims)
         )
 
 
-def _estimate_covariance(curr_estimate: List[List[Tuple[torch.Tensor]]],
-                         mlp_cache: List[MLPCache],
-                         total_samples: int,
-                         mask: torch.Tensor) -> List[List[Tuple[torch.Tensor]]]:
+def _estimate_covariance(
+    curr_estimate: List[List[Tuple[torch.Tensor]]],
+    mlp_cache: List[MLPCache],
+    total_samples: int,
+    mask: torch.Tensor,
+) -> List[List[Tuple[torch.Tensor]]]:
     """Estimate the 'covariance' matrices S and A in EK-FAC ihvp.
 
     Args:
@@ -1356,21 +1395,21 @@ def _estimate_covariance(curr_estimate: List[List[Tuple[torch.Tensor]]],
             else:
                 old_weight = total_samples / (total_samples + batch_samples)
                 new_weight = batch_samples / (total_samples + batch_samples)
-                new_cov_a = (old_weight * layer_cov[idx][0] +
-                             new_weight * batch_cov_a)
-                new_cov_s = (old_weight * layer_cov[idx][1] +
-                             new_weight * batch_cov_s)
+                new_cov_a = old_weight * layer_cov[idx][0] + new_weight * batch_cov_a
+                new_cov_s = old_weight * layer_cov[idx][1] + new_weight * batch_cov_s
                 layer_cov[idx] = (new_cov_a, new_cov_s)
 
     return curr_estimate
 
 
-def _estimate_lambda(curr_estimate: List[List[torch.Tensor]],
-                     mlp_cache: List[MLPCache],
-                     cached_q: List[List[Tuple[torch.Tensor]]],
-                     total_samples: int,
-                     mask: torch.Tensor,
-                     max_steps_for_vec: int = 10) -> List[List[torch.Tensor]]:
+def _estimate_lambda(
+    curr_estimate: List[List[torch.Tensor]],
+    mlp_cache: List[MLPCache],
+    cached_q: List[List[Tuple[torch.Tensor]]],
+    total_samples: int,
+    mask: torch.Tensor,
+    max_steps_for_vec: int = 10,
+) -> List[List[torch.Tensor]]:
     """Estimate the corrected eigenvalues in EK-FAC ihvp.
 
     Args:
@@ -1399,7 +1438,8 @@ def _estimate_lambda(curr_estimate: List[List[torch.Tensor]],
     """
     for cache, layer_lambda, layer_q in zip(mlp_cache, curr_estimate, cached_q):
         for idx, ((a_prev, s_curr), (q_a, q_s)) in enumerate(
-            zip(cache.input_hidden_pairs, layer_q)):
+            zip(cache.input_hidden_pairs, layer_q),
+        ):
             a_prev_masked = a_prev * mask[..., None].to(a_prev.device)
 
             # Uniformly reshape the tensors into (batch_size, t, ...)
@@ -1418,18 +1458,23 @@ def _estimate_lambda(curr_estimate: List[List[torch.Tensor]],
             timesteps = a_prev_reshaped.shape[1]  # the value of t
             if timesteps <= max_steps_for_vec:
                 # Vectorized calculation of dtheta
-                batch_dtheta = (ds_curr_reshaped.unsqueeze(-1) @
-                                a_prev_reshaped.unsqueeze(2)).sum(axis=1)
+                batch_dtheta = (
+                    ds_curr_reshaped.unsqueeze(-1) @ a_prev_reshaped.unsqueeze(2)
+                ).sum(axis=1)
             else:
                 # Memory efficient calculation of dtheta
-                batch_dtheta = torch.zeros(batch_samples,
-                                           ds_curr_reshaped.shape[-1],
-                                           a_prev_reshaped.shape[-1],
-                                           device=ds_curr.device)
+                batch_dtheta = torch.zeros(
+                    batch_samples,
+                    ds_curr_reshaped.shape[-1],
+                    a_prev_reshaped.shape[-1],
+                    device=ds_curr.device,
+                )
 
                 for ts in range(timesteps):
-                    batch_dtheta += (ds_curr_reshaped[:, ts, :, None] @
-                                     a_prev_reshaped[:, ts, None, :])
+                    batch_dtheta += (
+                        ds_curr_reshaped[:, ts, :, None]
+                        @ a_prev_reshaped[:, ts, None, :]
+                    )
 
             # An equivalent way to calculate lambda's. Please refer to
             # https://math.stackexchange.com/questions/1879933/vector-multiplication-with-multiple-kronecker-products
@@ -1442,19 +1487,22 @@ def _estimate_lambda(curr_estimate: List[List[torch.Tensor]],
             else:
                 old_weight = total_samples / (total_samples + batch_samples)
                 new_weight = batch_samples / (total_samples + batch_samples)
-                layer_lambda[idx] = (old_weight * layer_lambda[idx] +
-                                     new_weight * batch_lambda)
+                layer_lambda[idx] = (
+                    old_weight * layer_lambda[idx] + new_weight * batch_lambda
+                )
 
     return curr_estimate
 
 
-def ihvp_at_x_ekfac(func: Callable,
-                    *x,
-                    in_dims: Optional[Tuple] = None,
-                    batch_size: int = 1,
-                    max_iter: Optional[int] = None,
-                    mlp_cache: Union[MLPCache, List[MLPCache]],
-                    damping: float = 0.0) -> Callable:
+def ihvp_at_x_ekfac(
+    func: Callable,
+    *x,
+    in_dims: Optional[Tuple] = None,
+    batch_size: int = 1,
+    max_iter: Optional[int] = None,
+    mlp_cache: Union[MLPCache, List[MLPCache]],
+    damping: float = 0.0,
+) -> Callable:
     """IHVP via EK-FAC algorithm.
 
     Standing for the inverse-hessian-vector product, returns a function that,
@@ -1500,18 +1548,22 @@ def ihvp_at_x_ekfac(func: Callable,
         max_iter = (num_samples + batch_size - 1) // batch_size
 
     # 1. Use random batch to estimate covariance matrices S and A
-    dataloader = _random_batch_iterator(*x,
-                                        num_samples=num_samples,
-                                        in_dims=in_dims,
-                                        batch_size=batch_size)
+    dataloader = _random_batch_iterator(
+        *x,
+        num_samples=num_samples,
+        in_dims=in_dims,
+        batch_size=batch_size,
+    )
 
     cov_matrices = [[] for _ in range(len(mlp_cache))]
     total_samples = 0  # record total number of samples
     for i, batch in enumerate(dataloader):
         # Forward pass
         func_output = func(*batch)
-        losses, mask = (func_output if isinstance(func_output, tuple)
-                        else func_output, torch.tensor(1.))
+        losses, mask = (
+            func_output if isinstance(func_output, tuple) else func_output,
+            torch.tensor(1.0),
+        )
 
         for loss in losses:
             # Backward pass
@@ -1519,10 +1571,12 @@ def ihvp_at_x_ekfac(func: Callable,
 
         with torch.no_grad():
             # Estimate covariance
-            cov_matrices = _estimate_covariance(cov_matrices,
-                                                mlp_cache,
-                                                total_samples,
-                                                mask)
+            cov_matrices = _estimate_covariance(
+                cov_matrices,
+                mlp_cache,
+                total_samples,
+                mask,
+            )
 
         total_samples += int(mask.sum())
         if i == max_iter - 1:
@@ -1537,17 +1591,21 @@ def ihvp_at_x_ekfac(func: Callable,
             layer_q.append((q_a, q_s))
 
     # 3. Use random batch for eigenvalue correction
-    dataloader = _random_batch_iterator(*x,
-                                        num_samples=num_samples,
-                                        in_dims=in_dims,
-                                        batch_size=batch_size)
+    dataloader = _random_batch_iterator(
+        *x,
+        num_samples=num_samples,
+        in_dims=in_dims,
+        batch_size=batch_size,
+    )
     cached_lambdas = [[] for _ in range(len(mlp_cache))]
     total_samples = 0  # record total number of samples
     for i, batch in enumerate(dataloader):
         # Forward pass
         func_output = func(*batch)
-        losses, mask = (func_output if isinstance(func_output, tuple)
-                        else func_output, torch.tensor(1.))
+        losses, mask = (
+            func_output if isinstance(func_output, tuple) else func_output,
+            torch.tensor(1.0),
+        )
 
         for loss in losses:
             # Backward pass
@@ -1555,11 +1613,13 @@ def ihvp_at_x_ekfac(func: Callable,
 
         with torch.no_grad():
             # Update lambdas
-            cached_lambdas = _estimate_lambda(cached_lambdas,
-                                              mlp_cache,
-                                              cached_q,
-                                              total_samples,
-                                              mask)
+            cached_lambdas = _estimate_lambda(
+                cached_lambdas,
+                mlp_cache,
+                cached_q,
+                total_samples,
+                mask,
+            )
         total_samples += len(losses)
         if i == max_iter - 1:
             break
@@ -1579,14 +1639,14 @@ def ihvp_at_x_ekfac(func: Callable,
             The IHVP value.
         """
         ihvp = [[] for _ in range(len(cached_q))]
-        for layer_ihvp, layer_v, layer_lambda, layer_q in zip(ihvp, v,
-                                                              cached_lambdas,
-                                                              cached_q):
+        for layer_ihvp, layer_v, layer_lambda, layer_q in zip(
+            ihvp,
+            v,
+            cached_lambdas,
+            cached_q,
+        ):
             for _v, _lambda, (q_a, q_s) in zip(layer_v, layer_lambda, layer_q):
-                _ihvp = q_s.T @ (
-                    (q_s @ _v @ q_a.T) /
-                    (_lambda + damping)
-                    ) @ q_a
+                _ihvp = q_s.T @ ((q_s @ _v @ q_a.T) / (_lambda + damping)) @ q_a
                 layer_ihvp.append(_ihvp)
         return ihvp
 

--- a/dattri/func/ihvp.py
+++ b/dattri/func/ihvp.py
@@ -784,6 +784,10 @@ def ihvp_datainf(
         A function that takes a list of tuples of Tensor `x` and a tuple of tensors
         `v`(layer-wise) and returns the approximated IHVP of the approximated Hessian of
         `func` and `v`.
+
+    Raises:
+        IHVPUsageError: If the length of regularization is not the same as the number
+            of layers.
     """
     # TODO: param_layer_map should not be optional.
 
@@ -791,11 +795,17 @@ def ihvp_datainf(
     if regularization is not None and not isinstance(regularization, list):
         regularization = [regularization] * len(param_layer_map)
 
+    if len(regularization) != len(param_layer_map):
+        error_msg = "The length of regularization should\
+                     be the same as the number of layers."
+        raise IHVPUsageError(error_msg)
+
     def _single_datainf_ihvp(
         v: torch.Tensor,
         grad: torch.Tensor,
         regularization: float,
     ) -> torch.Tensor:
+        # TODO: docstring
         coef = (v @ grad) / (regularization + torch.sum(grad**2))
         return (v - coef.reshape(-1, 1) @ grad.reshape(1, -1)) / regularization
 
@@ -803,7 +813,7 @@ def ihvp_datainf(
         x: Tuple[torch.Tensor, ...],
         v: Tuple[torch.Tensor, ...],
     ) -> Tuple[torch.Tensor]:
-        """The IHVP function using CG.
+        """The IHVP function using DataInf.
 
         Args:
             x (Tuple[torch.Tensor, ...]): The function will compute the
@@ -902,6 +912,7 @@ def ihvp_at_x_datainf(
         grad: torch.Tensor,
         regularization: float,
     ) -> torch.Tensor:
+        # TODO: same as the `_single_datainf_ihvp` defined in `ihvp_datainf`.
         coef = (v.T @ grad) / (regularization + torch.sum(grad**2))
         return (v - coef * grad) / regularization
 
@@ -936,6 +947,8 @@ def ihvp_at_x_datainf(
         Returns:
             The IHVP value dictionary, with keys corresponding to layer names.
         """
+        # TODO: seems to be redundant if we have `_ihvp_datainf_func``
+        # some code might be reused.
         ihvps = []
         for layer in range(layer_cnt):
             reg = 0.0 if regularization is None else regularization[layer]

--- a/dattri/func/ihvp.py
+++ b/dattri/func/ihvp.py
@@ -775,7 +775,6 @@ def ihvp_datainf(
             The regularization term is `regularization * I`, where `I` is the
             identity matrix directly added to the Hessian matrix. The list is
             of length L, where L is the total number of layers.
-        TODO: param_layer_map should not be optional.
         param_layer_map: Optional[List[int]]: Specifies how the parameters are grouped
             into layers. Should be the same length as parameters tuple. For example,
             for a two layer model, params = (0.weights1,0.bias,1.weights,1.bias),
@@ -786,6 +785,8 @@ def ihvp_datainf(
         `v`(layer-wise) and returns the approximated IHVP of the approximated Hessian of
         `func` and `v`.
     """
+    # TODO: param_layer_map should not be optional.
+
     batch_grad_func = vmap(grad(func, argnums=argnums), in_dims=in_dims)
     if regularization is not None and not isinstance(regularization, list):
         regularization = [regularization] * len(param_layer_map)

--- a/dattri/func/utils.py
+++ b/dattri/func/utils.py
@@ -188,7 +188,17 @@ def _unflatten_params_layerwise(
     tensors: Tuple[torch.Tensor, ...],
     model: torch.nn.Module,
 ) -> Tuple[torch.Tensor, ...]:
-    """Unflatten a tuple of tensors into a dictionaries of tensors."""
+    """Unflatten a tuple of tensors into a dictionaries of tensors.
+
+    Args:
+        tensors: A tuple of tensors containing the flattened parameters.
+        model: A torch.nn.Module object, providing the shape information and the names
+            of the parameters.
+
+    Returns:
+        (Tuple[torch.Tensor, ...]): A tuple of tensors containing the unflattened
+            parameters.
+    """
     model_params = {k: p for k, p in model.named_parameters() if p.requires_grad}
     keys = list(model_params.keys())
     param_dict = {}

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -16,7 +16,7 @@ from dattri.func.utils import flatten_func, flatten_params
 
 
 class AttributionTask:
-    """The abstraction of the abstraction task."""
+    """The abstraction of the attribution task information."""
 
     def __init__(
         self,
@@ -33,7 +33,7 @@ class AttributionTask:
 
         Args:
             target_func (Callable): The target function to be attributed.
-                The function can be quite flexible in terms of what is calculate,
+                The function can be quite flexible in terms of what is calculated,
                 but it should take the parameters and the data as input. Other than
                 that, the forwarding of model should be in `torch.func` style.
                 A typical example is as follows:
@@ -100,7 +100,13 @@ class AttributionTask:
                 The named parameters of the model.
 
         Returns:
-            List[int]: The map from the parameter to the layer.
+            List[int]: The map from the parameter
+                to the layer. If None, the map will be generated automatically. Normally
+                this should not be stated explicitly by the user, if needed it should
+                be the same length as parameters tuple. For example,
+                for a two layer model, params = (0.weights1, 0.bias, 1.weights, 1.bias),
+                param_layer_map should be [0, 0, 1, 1],resulting in two layers
+                as expected.
         """
         named_parameters_keys = named_parameters.keys()
         param_layer_map = []

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -1,0 +1,238 @@
+"""Defines the task abstractions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Dict, List, Optional, Tuple, Union
+
+import torch
+from torch import nn
+from torch.func import grad, vmap
+
+from dattri.func.utils import flatten_func, flatten_params
+
+
+class AttributionTask:
+    """The abstraction of the abstraction task."""
+
+    def __init__(
+        self,
+        target_func: Callable,
+        model: nn.Module,
+        checkpoints: Union[
+            str,
+            List[str],
+            List[Dict[str, torch.Tensor]],
+            Dict[str, torch.Tensor],
+        ],
+    ) -> None:
+        """Initialize the AttributionTask.
+
+        Args:
+            target_func (Callable): The target function to be attributed.
+                The function can be quite flexible in terms of what is calculate,
+                but it should take the parameters and the data as input. Other than
+                that, the forwarding of model should be in `torch.func` style.
+                A typical example is as follows:
+                ```python
+                def f(params, data):
+                    image, label = data
+                    loss = nn.CrossEntropyLoss()
+                    yhat = torch.func.functional_call(model, params, image)
+                    return loss(yhat, label)
+                ```.
+                This examples calculates the CE loss of the model on the data.
+            model (nn.Module): The model that the target function is based on.
+                To be more specific, the model is the `model` used in the target
+                function. Since only the computation graph of the model will be
+                used, so it is allowed that this model is not loaded with a trained
+                parameters.
+            checkpoints:
+                (Union[str, List[str], List[Dict[str, torch.Tensor]],
+                Dict[str, torch.Tensor]]): The checkpoints
+                of the model, both dictionary of the state_dict and the path to
+                the checkpoint are supported. If ensemble is needed, a list of
+                checkpoint is also supported.
+
+        """
+        self.model = model
+        self.target_func = flatten_func(self.model)(target_func)
+
+        if not isinstance(checkpoints, list):
+            self.checkpoints = [checkpoints]
+        else:
+            self.checkpoints = checkpoints
+
+        # current_checkpoint_idx is used to state
+        # which checkpoint is currently loaded.
+        self.current_checkpoint_idx = None
+
+        # TODO: Make this more general, that is allow customized kwargs.
+        self.grad_func = vmap(grad(self.target_func), in_dims=(None, 1))
+
+    def _load_checkpoints(self, index: int) -> None:
+        """This method load the checkpoint at the specified index.
+
+        Args:
+            index (int): The index of the checkpoint to be loaded.
+        """
+        if self.current_checkpoint_idx is None or self.current_checkpoint_idx != index:
+            if isinstance(self.checkpoints[index], str):
+                self.model.load_state_dict(torch.load(self.checkpoints[index]))
+            else:
+                self.model.load_state_dict(self.checkpoints[index])
+            self.current_checkpoint_idx = index
+            self.named_parameters = {
+                k: p for k, p in self.model.named_parameters() if p.requires_grad
+            }
+
+    @staticmethod
+    def _genearte_param_layer_map(
+        named_parameters: Dict[str, torch.Tensor],
+    ) -> List[int]:
+        """This function generate the param_layer_map automatically.
+
+        Args:
+            named_parameters (Dict[str, torch.Tensor]):
+                The named parameters of the model.
+
+        Returns:
+            List[int]: The map from the parameter to the layer.
+        """
+        named_parameters_keys = named_parameters.keys()
+        param_layer_map = []
+
+        current_layer = None
+        current_index = -1
+        for key in named_parameters_keys:
+            layer_name = ".".join(key.split(".")[:-1])
+            if layer_name != current_layer:
+                current_index += 1
+                current_layer = layer_name
+            param_layer_map.append(current_index)
+
+        return param_layer_map
+
+    def get_grad_target_func(
+        self,
+        layer_name: Optional[Union[str, List[str]]] = None,
+    ) -> Callable:
+        """Return a function that computes the gradient of the target function.
+
+        TODO: support partial parameter gradient.
+
+        Args:
+            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+
+        Returns:
+            Callable: The function that computes the gradient of the target function.
+
+        Raises:
+            NotImplementedError: If layer_name is not None.
+        """
+        if layer_name is not None:
+            error_msg = "layer_name has not been implemented yet."
+            raise NotImplementedError(error_msg)
+        return self.grad_func
+
+    def get_target_func(
+        self,
+        layer_name: Optional[Union[str, List[str]]] = None,
+    ) -> Callable:
+        """Return a function that computes the gradient of the target function.
+
+        TODO: support partial parameter gradient.
+
+        Args:
+            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+
+        Returns:
+            Callable: The target function itself.
+
+        Raises:
+            NotImplementedError: If layer_name is not None.
+        """
+        if layer_name is not None:
+            error_msg = "layer_name has not been implemented yet."
+            raise NotImplementedError(error_msg)
+        return self.target_func
+
+    def get_param(
+        self,
+        index: int = 0,
+        layer_name: Optional[Union[str, List[str]]] = None,
+        layer_split: Optional[bool] = False,
+        param_layer_map: Optional[List[int]] = None,
+    ) -> Tuple[Union[torch.Tensor, List[torch.Tensor]], Optional[List[int]]]:
+        """Return the flattened parameter of the model.
+
+        Args:
+            index (int): The index of the checkpoint to be loaded.
+            layer_name (Optional[Union[str, List[str]]]): The name of the layer to be
+                extracted. If None, all the parameters will be returned. This should be
+                a string or a list of strings if multiple layers are needed. The name
+                of layer should follow the key of model.named_parameters().
+            layer_split (Optional[bool]): If True, the parameters will be split
+                into different layers and returned as a list of parameter tensors.
+            param_layer_map (Optional[List[int]]): The map from the parameter
+                to the layer. If None, the map will be generated automatically. Normally
+                this should not be stated explicitly by the user, if needed it should
+                be the same length as parameters tuple. For example,
+                for a two layer model, params = (0.weights1, 0.bias, 1.weights, 1.bias),
+                param_layer_map should be [0, 0, 1, 1],resulting in two layers
+                as expected.
+
+        Returns:
+            Tuple[Union[torch.Tensor, List[torch.Tensor]], Optional[List[int]]]: The
+                flattened parameters of the model and the layer map if layer_split
+                is True. Flattened parameters will be a 1-dim tensor.
+
+        Raises:
+            ValueError: If the length of param_layer_map is not the same as the length
+                of named_parameters
+        """
+        self._load_checkpoints(index)
+
+        if layer_name:
+            named_parameters = {
+                k: self.named_parameters[k]
+                for k in layer_name
+                if k in self.named_parameters
+            }
+        else:
+            named_parameters = self.named_parameters
+
+        if layer_split:
+            if param_layer_map:
+                if len(param_layer_map) == len(
+                    named_parameters,
+                ):
+                    error_msg = (
+                        "param_layer_map must have the same len as named_parameters."
+                    )
+                    raise ValueError(error_msg)
+                return tuple(
+                    [param.flatten() for param in named_parameters.values()],
+                ), param_layer_map
+            return tuple(
+                [param.flatten() for param in named_parameters.values()],
+            ), self._genearte_param_layer_map(named_parameters)
+        return flatten_params(named_parameters), None
+
+    def register_forward_hook(  # noqa:PLR6301
+        self,
+        layer_name: Union[str, List[str]],  # noqa: ARG002
+    ) -> Tuple[torch.Tensors, ...]:
+        """Register forward hook to specified layer_name.
+
+        Args:
+            layer_name (Union[str, List[str]]): The name of the layer to be registered.
+
+        Raises:
+            NotImplementedError: This method has not been implemented yet.
+        """
+        error_msg = "This method has not been implemented yet."
+        raise NotImplementedError(error_msg)

--- a/docs/source/api/algorithm.rst
+++ b/docs/source/api/algorithm.rst
@@ -1,6 +1,6 @@
 Attributors
 =======
-.. autoclass:: dattri.algorithm.influence_function.IFAttributor
+.. automodule:: dattri.algorithm.influence_function
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/api/task.rst
+++ b/docs/source/api/task.rst
@@ -1,0 +1,6 @@
+Tasks
+=======
+.. autoclass:: dattri.task.AttributionTask
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@
    :maxdepth: 1
    :caption: Attribution Methods:
 
+   api/task.rst
    api/algorithm.rst
    api/helper.rst
 

--- a/example/cifar2_resnet9/influence_function_noisy_label.py
+++ b/example/cifar2_resnet9/influence_function_noisy_label.py
@@ -38,9 +38,6 @@ if __name__ == "__main__":
     parser.add_argument("--device", type=str, default="cuda")
     args = parser.parse_args()
 
-    transform = transforms.Compose([transforms.ToTensor(),
-                                    transforms.Normalize((0.5, 0.5, 0.5),
-                                                         (0.5, 0.5, 0.5))])
     train_dataset, _ = create_cifar2_dataset("./data")
 
     flip_index = get_cifar_indices_and_adjust_labels(train_dataset, range(1000))

--- a/example/cifar2_resnet9/influence_function_noisy_label.py
+++ b/example/cifar2_resnet9/influence_function_noisy_label.py
@@ -1,35 +1,43 @@
 """This example shows how to use the IF to detect noisy labels in the MNIST."""
 
 import time
+import argparse
+from functools import partial
+
 import torch
 from torch import nn
-from torch.utils.data import Sampler
 from torchvision import transforms
 
-from dattri.algorithm.influence_function import IFAttributor
+from dattri.algorithm.influence_function import\
+    IFAttributorExplicit,\
+    IFAttributorCG,\
+    IFAttributorLiSSA,\
+    IFAttributorDataInf,\
+    IFAttributorArnoldi
 from dattri.benchmark.datasets.cifar2 import create_cifar2_dataset, train_cifar2_resnet9
 from dattri.benchmark.utils import flip_label
-from dattri.func.utils import flatten_func
+from dattri.benchmark.utils import SubsetSampler
+from dattri.task import AttributionTask
+
+ATTRIBUTOR_MAP = {
+    "explicit": partial(IFAttributorExplicit, regularization=0.01),
+    "cg": partial(IFAttributorCG, regularization=0.01, max_iter=1),
+    "lissa": partial(IFAttributorLiSSA, recursion_depth=100),
+    "datainf": partial(IFAttributorDataInf, regularization=0.01),
+    "arnoldi": partial(IFAttributorArnoldi, regularization=0.01, max_iter=10)
+}
 
 
 def get_cifar_indices_and_adjust_labels(dataset, subset_indice):
-
     dataset.targets, flip_index = flip_label(torch.tensor(dataset.targets)[subset_indice], p=0.1)
     return flip_index
 
-
-class SubsetSampler(Sampler):
-    def __init__(self, indices):
-        self.indices = indices
-
-    def __iter__(self):
-        return iter(self.indices)
-
-    def __len__(self):
-        return len(self.indices)
-
-
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--method", type=str, default="explicit")
+    parser.add_argument("--device", type=str, default="cuda")
+    args = parser.parse_args()
+
     transform = transforms.Compose([transforms.ToTensor(),
                                     transforms.Normalize((0.5, 0.5, 0.5),
                                                          (0.5, 0.5, 0.5))])
@@ -53,26 +61,23 @@ if __name__ == "__main__":
         sampler=SubsetSampler(range(1000)),
     )
 
-    model = train_cifar2_resnet9(train_loader, device="cuda", num_epochs=20)
+    model = train_cifar2_resnet9(train_loader, device="cuda", num_epochs=1)
     model.cuda()
     model.eval()
 
-    @flatten_func(model)
     def f(params, data_target_pair):
         image, label = data_target_pair
         loss = nn.CrossEntropyLoss()
         yhat = torch.func.functional_call(model, params, image)
-        return loss(yhat, label)
+        return loss(yhat, label.long())
 
+    task = AttributionTask(target_func=f,
+                           model=model,
+                           checkpoints=model.state_dict())
 
-    model_params = {k: p for k, p in model.named_parameters() if p.requires_grad}
-
-    attributor = IFAttributor(
-        target_func=f,
-        params=model_params,
-        ihvp_solver="cg",
-        ihvp_kwargs={"regularization": 1e-3},
-        device=torch.device("cuda"),
+    attributor = ATTRIBUTOR_MAP[args.method](
+        task=task,
+        device=args.device,
     )
 
     attributor.cache(train_loader_full)

--- a/example/mnist_lr/influence_function_noisy_label.py
+++ b/example/mnist_lr/influence_function_noisy_label.py
@@ -14,7 +14,7 @@ from dattri.algorithm.influence_function import\
     IFAttributorLiSSA,\
     IFAttributorDataInf,\
     IFAttributorArnoldi
-from dattri.benchmark.datasets.mnist import train_mnist_lr
+from dattri.benchmark.datasets.mnist import train_mnist_lr, create_mnist_dataset
 from dattri.benchmark.utils import flip_label
 from dattri.benchmark.utils import SubsetSampler
 from dattri.task import AttributionTask
@@ -40,13 +40,7 @@ if __name__ == "__main__":
     parser.add_argument("--device", type=str, default="cuda")
     args = parser.parse_args()
 
-    transform = transforms.Compose(
-        [
-            transforms.ToTensor(),
-            transforms.Normalize((0.1307,), (0.3081,)),
-        ],
-    )
-    dataset = datasets.MNIST("../data", train=True, download=True, transform=transform)
+    dataset, _ = create_mnist_dataset("./data")
 
     flip_index = get_mnist_indices_and_adjust_labels(dataset)
 

--- a/example/mnist_lr/influence_function_noisy_label.py
+++ b/example/mnist_lr/influence_function_noisy_label.py
@@ -1,15 +1,31 @@
 """This example shows how to use the IF to detect noisy labels in the MNIST."""
 
 import time
+import argparse
+from functools import partial
+
 import torch
 from torch import nn
-from torch.utils.data import Sampler
 from torchvision import datasets, transforms
 
-from dattri.algorithm.influence_function import IFAttributor
-from dattri.benchmark.datasets.mnist import train_mnist_lr, train_mnist_mlp
+from dattri.algorithm.influence_function import\
+    IFAttributorExplicit,\
+    IFAttributorCG,\
+    IFAttributorLiSSA,\
+    IFAttributorDataInf,\
+    IFAttributorArnoldi
+from dattri.benchmark.datasets.mnist import train_mnist_lr
 from dattri.benchmark.utils import flip_label
-from dattri.func.utils import flatten_func
+from dattri.benchmark.utils import SubsetSampler
+from dattri.task import AttributionTask
+
+ATTRIBUTOR_MAP = {
+    "explicit": partial(IFAttributorExplicit, regularization=0.01),
+    "cg": partial(IFAttributorCG, regularization=0.01),
+    "lissa": partial(IFAttributorLiSSA, recursion_depth=100),
+    "datainf": partial(IFAttributorDataInf, regularization=0.01),
+    "arnoldi": partial(IFAttributorArnoldi, regularization=0.01, max_iter=10)
+}
 
 
 def get_mnist_indices_and_adjust_labels(dataset):
@@ -17,18 +33,13 @@ def get_mnist_indices_and_adjust_labels(dataset):
     return flip_index
 
 
-class SubsetSampler(Sampler):
-    def __init__(self, indices):
-        self.indices = indices
-
-    def __iter__(self):
-        return iter(self.indices)
-
-    def __len__(self):
-        return len(self.indices)
-
-
 if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--method", type=str, default="explicit")
+    parser.add_argument("--device", type=str, default="cuda")
+    args = parser.parse_args()
+
     transform = transforms.Compose(
         [
             transforms.ToTensor(),
@@ -39,42 +50,41 @@ if __name__ == "__main__":
 
     flip_index = get_mnist_indices_and_adjust_labels(dataset)
 
+    # for model training
     train_loader_full = torch.utils.data.DataLoader(
         dataset,
-        batch_size=1000,
+        batch_size=64,
         sampler=SubsetSampler(range(1000)),
     )
+    # training samples for attribution
     train_loader = torch.utils.data.DataLoader(
         dataset,
-        batch_size=64,
+        batch_size=500,
         sampler=SubsetSampler(range(1000)),
     )
+    # test samples for attribution
     test_loader = torch.utils.data.DataLoader(
         dataset,
-        batch_size=64,
+        batch_size=500,
         sampler=SubsetSampler(range(1000)),
     )
 
-    model = train_mnist_mlp(train_loader_full)
+    model = train_mnist_lr(train_loader_full)
     model.cuda()
     model.eval()
 
-    @flatten_func(model)
     def f(params, data_target_pair):
         image, label = data_target_pair
         loss = nn.CrossEntropyLoss()
         yhat = torch.func.functional_call(model, params, image)
-        return loss(yhat, label)
+        return loss(yhat, label.long())
 
-
-    model_params = {k: p for k, p in model.named_parameters() if p.requires_grad}
-    attributor = IFAttributor(
-        target_func=f,
-        params=model_params,
-        ihvp_solver="cg",
-        # ihvp_kwargs={"recursion_depth": 100, "batch_size": 10},  # lissa
-        ihvp_kwargs={"regularization": 1e-3},
-        device=torch.device("cuda"),
+    task = AttributionTask(target_func=f,
+                           model=model,
+                           checkpoints=model.state_dict())
+    attributor = ATTRIBUTOR_MAP[args.method](
+        task=task,
+        device=args.device,
     )
 
     attributor.cache(train_loader_full)


### PR DESCRIPTION
## Description

### 1. Motivation and Context
1. Introduce a new `AttributionTask` class to manage model and checkpoint information, in order to reduce user's workload on extracting internal information of the models needed for some algorithms.
2. Make 2 levels of Attributor API, which makes it easier for users to build customized attributors from our template rather than directly from scratch.
3. Support DataInf as one of the attributors.
4. All examples, unittests and API documents are changed accordingly.

### 2. Summary of the change
1. Introduce a new `AttributionTask` API, so that users will follow the following template for attributor usage
```python
# User code
model = create_model()

def f(params, data_target_pair):
    image, label = data_target_pair
    loss = nn.CrossEntropyLoss()
    yhat = torch.func.functional_call(model, params, image)
    return loss(yhat, label.long())

task = AttributionTask(target_func=f, model=model, checkpoints=model.state_dict())
attributor = Attributor(task=task, device="cuda")
```

This `AttributionTask` contains some useful member functions that are very helpful for attributor development.
```python
# Developer code
task.get_grad_target_func(...)  # get the targeted function's gradient func
task.get_target_func(...)  # get the targeted function, which can be directly used by dattri.func
task.get_param(...)  # get the parameters w/ or w/o layer split, as well as the layer mapping automatically (for datainf and ek-fac)
task.register_forward_hook(...)  # TODO, return the handler of the hook for hidden states.
```

2. Refactors the original IFAttributors into a more flexible `BaseInnerProductAttributor` and some high-level implementations of Attributors.

Users who do not want to customize their own attributor may directly use the high-level implementations of Attributors.

```python
# User code
from dattri.algorithm.influence_function import\
    IFAttributorExplicit,\
    IFAttributorCG,\
    IFAttributorLiSSA,\
    IFAttributorDataInf,\
    IFAttributorArnoldi

attributor = IFAttributorExplicit(task=task, device="cuda", regularization=0.01)
attributor = IFAttributorCG(task=task, device="cuda", regularization=0.01)
attributor = IFAttributorLiSSA(task=task, device="cuda", recursion_depth=100)
attributor = IFAttributorDataInf(task=task, device="cuda", regularization=0.01)
attributor = IFAttributorArnoldi(task=task, device="cuda", regularization=0.01)

# following usage is not changed (i.e., attributor.cache() and attributor.attribute())
```

Developers who want to create their own attributors may follow the templates we provided, currently we have `BaseInnerProductAttributor` for a large family of gradient-based TDA methods that has (g^TH^{-1}g) format.

It can also support
- GradCos/GradDot
- IF
- Embedding similarity based TDA methods

```python
class MyAttributor(BaseInnerProductAttributor):
    def generate_test_query(
        self,
        index: int,
        data: Tuple[torch.Tensor, ...],
    ) -> torch.Tensor:
        # this methods defaultly calculate the gradient over test samples
        # but developers may want to have their own design, .e.g, use some projectors.
        model_params, _ = self.task.get_param(index)
        return self.task.get_grad_target_func()(model_params, data)

    def generate_train_query(
        self,
        index: int,
        data: Tuple[torch.Tensor, ...],
    ) -> torch.Tensor:
        # this methods defaultly calculate the gradient over train samples
        # but developers may want to have their own design, .e.g, use some projectors.
        model_params, _ = self.task.get_param(index)
        return self.task.get_grad_target_func()(model_params, data)

    def transformation_on_query(
        self,
        index: int,
        data: Tuple[torch.Tensor, ...],
        query: torch.Tensor,
        **transformation_kwargs
    ) -> torch.Tensor:
       # This methods is called on the test query (as the vector)
       # IF will calculate the Hessian/Fisher and make the ihvp or ifvp
       # Grad-cos/dot will directly return the test query.

       # Let's take explicitly IHVP as example
       from dattri.func.ihvp import ihvp_explicit

        self.ihvp_func = ihvp_explicit(
            partial(self.task.get_target_func(), data_target_pair=data),
            **transformation_kwargs,
        )
        model_params, _ = self.task.get_param(index)
        return self.ihvp_func((model_params,), query).detach()
```

3. DataInf can be directly supported under this design, **with no additional work on the users' side**.

### 3. What tests have been added/updated for the change?
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
- [x] Document test: If you added an external API, then you should check if the document is correctly generated.

### 4. TODOs
Some todos will be added to the project tracking page.