### PR TITLE
[dattri.algorithm] Fix bugs in TRAK projection

### DIFF
--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -63,6 +63,10 @@ class TRAKAttributor(BaseAttributor):
             projector_kwargs (Optional[Dict[str, Any]], optional): The kwargs for the
                 random projection. Defaults to None.
             device (str): The device to run the attributor. Default is cpu.
+
+        Raise:
+            ValueError: If the provided model contains layers with more parameters
+                than `max_chunk_size` of the selected cuda projector.
         """
         self.task = task
         self.norm_scaler = (

--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -64,7 +64,7 @@ class TRAKAttributor(BaseAttributor):
                 random projection. Defaults to None.
             device (str): The device to run the attributor. Default is cpu.
 
-        Raise:
+        Raises:
             ValueError: If the provided model contains layers with more parameters
                 than `max_chunk_size` of the selected cuda projector.
         """

--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -108,6 +108,21 @@ class TRAKAttributor(BaseAttributor):
                 grad_t = self.grad_func(parameters, train_batch_data)
                 grad_t = torch.nan_to_num(grad_t)
                 grad_t /= self.norm_scaler
+
+                # Unflatten the gradient tensors
+                grad_t = [
+                    _unflatten_params(g, self.task.model)
+                    for g in grad_t
+                ]
+
+                # Stack the gradient tensors for each layer
+                grad_t = {
+                    key: torch.stack(
+                        [g[key] for g in grad_t],
+                        ).view(len(grad_t), -1)
+                    for key in grad_t[0]
+                }
+
                 grad_p = (
                     random_project(
                         grad_t,
@@ -210,6 +225,20 @@ class TRAKAttributor(BaseAttributor):
                     grad_t = torch.nan_to_num(grad_t)
                     grad_t /= self.norm_scaler
 
+                    # Unflatten the gradient tensors
+                    grad_t = [
+                        _unflatten_params(g, self.task.model)
+                        for g in grad_t
+                    ]
+
+                    # Stack the gradient tensors for each layer
+                    grad_t = {
+                        key: torch.stack(
+                            [g[key] for g in grad_t],
+                            ).view(len(grad_t), -1)
+                        for key in grad_t[0]
+                    }
+
                     grad_p = (
                         random_project(
                             grad_t,
@@ -244,6 +273,20 @@ class TRAKAttributor(BaseAttributor):
                 grad_t = self.grad_func(parameters, test_batch_data)
                 grad_t = torch.nan_to_num(grad_t)
                 grad_t /= self.norm_scaler
+
+                # Unflatten the gradient tensors
+                grad_t = [
+                    _unflatten_params(g, self.task.model)
+                    for g in grad_t
+                ]
+
+                # Stack the gradient tensors for each layer
+                grad_t = {
+                    key: torch.stack(
+                        [g[key] for g in grad_t],
+                        ).view(len(grad_t), -1)
+                    for key in grad_t[0]
+                }
 
                 grad_p = (
                     random_project(


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context

<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

Current TRAK projection fails for large models. Since all the parameters are flattened and concatenated together, as long as the total number of parameters is larger than `max_chunk_size`, the projector will fail to arrange inputs correctly and raise an internal error.

### 2. Summary of the change

This pr changes the inputs passed to the projector from a large tensor to a dictionary and add necessary condition check for the input model.

Specifically, modified `TRAKAttributor` in `dattri.algorithm.trak`


<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. What tests have been added/updated for the change?
- [x] N/A: No test will be added
This error only occurs for large models (at least > 0.1b). The error is not caused by any problems in the modules, but by the input format.
