### PR TITLE
[dattri.task] Add `loss_func` and make `target_func` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install dattri[all]
 ### Apply Data Attribution methods on PyTorch Models
 
 One can apply different data attribution methods on PyTorch Models. One only needs to define:
-1. loss function used for model training
+1. loss function used for model training (will be used as target function to be attributed if no other target function provided).
 2. trained model checkpoints.
 3. the data loaders for training samples and test samples (e.g., `train_loader`, `test_loader`).
 4. (optional) target function to be attributed if it's not the same as loss function.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ pip install dattri[all]
 ### Apply Data Attribution methods on PyTorch Models
 
 One can apply different data attribution methods on PyTorch Models. One only needs to define:
-1. a target function (e.g., `f`)
+1. loss function used for model training
 2. trained model checkpoints.
 3. the data loaders for training samples and test samples (e.g., `train_loader`, `test_loader`).
+4. (optional) target function to be attributed if it's not the same as loss function.
 
 The following is an example to use `IFAttributorCG` and `AttributionTask` to apply data attribution to a PyTorch model.
 
@@ -44,13 +45,13 @@ The following is an example to use `IFAttributorCG` and `AttributionTask` to app
 from dattri.algorithm import IFAttributorCG
 from dattri.task import AttributionTask
 
-def f(params, data): # an example of target function using CE loss
+def f(params, data): # an example of loss function using CE loss
     x, y = data
     loss = nn.CrossEntropyLoss()
     yhat = torch.func.functional_call(model, params, x)
     return loss(yhat, y)
 
-task = AttributionTask(target_func=f,
+task = AttributionTask(loss_func=f,
                        model=model,
                        checkpoints=model.state_dict())
 
@@ -72,7 +73,7 @@ Hessian-vector product (HVP), inverse-Hessian-vector product
 ```python
 from dattri.func.hessian import ihvp_cg, ihvp_at_x_cg
 
-def f(x, param): # target function
+def f(x, param):
     return torch.sin(x / param).sum()
 
 x = torch.randn(2)
@@ -102,7 +103,7 @@ project_func = random_project(tensor, tensor.size(0), proj_dim=512)
 projected_tensor = project_func(torch.full_like(tensor))
 ```
 
-Normally speaking, `tensor` is probably the gradient of target function and has a large dimension (i.e., the number of parameters).
+Normally speaking, `tensor` is probably the gradient of loss/target function and has a large dimension (i.e., the number of parameters).
 
 #### Dropout Ensemble
 Recent studies found that ensemble methods can significantly improve the performance of data attribution, [DROPOUT ENSEMBLE](https://arxiv.org/pdf/2405.17293) is one of these ensemble methods. One may prepare their model with

--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from typing import Any, Dict, Optional, Tuple
 
     import torch
@@ -26,11 +25,10 @@ class BaseAttributor(ABC):
     """BaseAttributor."""
 
     @abstractmethod
-    def __init__(self, target_func: Callable, **kwargs: dict) -> None:
+    def __init__(self, **kwargs: dict) -> None:
         """Initialize the attributor.
 
         Args:
-            target_func (Callable): The target function to be attributed.
             **kwargs (dict): The keyword arguments for the attributor.
 
         Returns:
@@ -176,7 +174,7 @@ class BaseInnerProductAttributor(BaseAttributor):
                 (batchsize, num_parameters).
         """
         model_params, _ = self.task.get_param(index)
-        return self.task.get_grad_target_func()(model_params, data)
+        return self.task.get_grad_loss_func()(model_params, data)
 
     @abstractmethod
     def transformation_on_query(

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -48,7 +48,7 @@ class IFAttributorExplicit(BaseInnerProductAttributor):
         from dattri.func.hessian import ihvp_explicit
 
         self.ihvp_func = ihvp_explicit(
-            partial(self.task.get_target_func(), data_target_pair=train_data),
+            partial(self.task.get_loss_func(), data_target_pair=train_data),
             **transformation_kwargs,
         )
         model_params, _ = self.task.get_param(index)
@@ -87,7 +87,7 @@ class IFAttributorCG(BaseInnerProductAttributor):
         from dattri.func.hessian import ihvp_cg
 
         self.ihvp_func = ihvp_cg(
-            partial(self.task.get_target_func(), data_target_pair=train_data),
+            partial(self.task.get_loss_func(), data_target_pair=train_data),
             **transformation_kwargs,
         )
         model_params, _ = self.task.get_param(index)
@@ -126,7 +126,7 @@ class IFAttributorArnoldi(BaseInnerProductAttributor):
         from dattri.func.hessian import ihvp_arnoldi
 
         self.ihvp_func = ihvp_arnoldi(
-            partial(self.task.get_target_func(), data_target_pair=train_data),
+            partial(self.task.get_loss_func(), data_target_pair=train_data),
             **transformation_kwargs,
         )
         model_params, _ = self.task.get_param(index)
@@ -165,7 +165,7 @@ class IFAttributorLiSSA(BaseInnerProductAttributor):
         from dattri.func.hessian import ihvp_lissa
 
         self.ihvp_func = ihvp_lissa(
-            self.task.get_target_func(),
+            self.task.get_loss_func(),
             collate_fn=IFAttributorLiSSA.lissa_collate_fn,
             **transformation_kwargs,
         )
@@ -228,7 +228,7 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
         model_params, param_layer_map = self.task.get_param(index, layer_split=True)
 
         self.ihvp_func = ifvp_datainf(
-            self.task.get_target_func(),
+            self.task.get_loss_func(),
             0,
             (None, 0),
             param_layer_map=param_layer_map,

--- a/dattri/algorithm/tracin.py
+++ b/dattri/algorithm/tracin.py
@@ -55,7 +55,8 @@ class TracInAttributor(BaseAttributor):
         self.device = device
         self.full_train_dataloader = None
         # to get per-sample gradients for a mini-batch of train/test samples
-        self.grad_func = self.task.get_grad_target_func(in_dims=(None, 0))
+        self.grad_target_func = self.task.get_grad_target_func(in_dims=(None, 0))
+        self.grad_loss_func = self.task.get_grad_loss_func(in_dims=(None, 0))
 
     def cache(self) -> None:
         """Precompute and cache some values for efficiency."""
@@ -117,7 +118,7 @@ class TracInAttributor(BaseAttributor):
                     data.to(self.device) for data in train_batch_data_
                 )
                 # get gradient of train
-                grad_t = self.grad_func(parameters, train_batch_data)
+                grad_t = self.grad_loss_func(parameters, train_batch_data)
                 if self.projector_kwargs is not None:
                     # define the projector for this batch of data
                     self.train_random_project = random_project(
@@ -146,7 +147,7 @@ class TracInAttributor(BaseAttributor):
                         data.to(self.device) for data in test_batch_data_
                     )
                     # get gradient of test
-                    grad_t = self.grad_func(parameters, test_batch_data)
+                    grad_t = self.grad_target_func(parameters, test_batch_data)
                     if self.projector_kwargs is not None:
                         # define the projector for this batch of data
                         self.test_random_project = random_project(

--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -72,7 +72,8 @@ class TRAKAttributor(BaseAttributor):
         if projector_kwargs is not None:
             self.projector_kwargs.update(projector_kwargs)
         self.device = device
-        self.grad_func = self.task.get_grad_target_func(in_dims=(None, 0))
+        self.grad_target_func = self.task.get_grad_target_func(in_dims=(None, 0))
+        self.grad_loss_func = self.task.get_grad_loss_func(in_dims=(None, 0))
         self.correct_probability_func = vmap(
             correct_probability_func,
             in_dims=(None, 0),
@@ -105,7 +106,7 @@ class TRAKAttributor(BaseAttributor):
                 leave=False,
             ):
                 train_batch_data = tuple(data.to(self.device) for data in train_data)
-                grad_t = self.grad_func(parameters, train_batch_data)
+                grad_t = self.grad_loss_func(parameters, train_batch_data)
                 grad_t = torch.nan_to_num(grad_t)
                 grad_t /= self.norm_scaler
                 grad_p = (
@@ -203,7 +204,7 @@ class TRAKAttributor(BaseAttributor):
                     train_batch_data = tuple(
                         data.to(self.device) for data in train_data
                     )
-                    grad_t = self.grad_func(
+                    grad_t = self.grad_loss_func(
                         parameters,
                         train_batch_data,
                     )
@@ -241,7 +242,7 @@ class TRAKAttributor(BaseAttributor):
                 leave=False,
             ):
                 test_batch_data = tuple(data.to(self.device) for data in test_data)
-                grad_t = self.grad_func(parameters, test_batch_data)
+                grad_t = self.grad_target_func(parameters, test_batch_data)
                 grad_t = torch.nan_to_num(grad_t)
                 grad_t /= self.norm_scaler
 

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -39,6 +39,8 @@ class AttributionTask:
                 The function can be quite flexible in terms of what is calculated,
                 but it should take the parameters and the data as input. Other than
                 that, the forwarding of model should be in `torch.func` style.
+                It will be used as target function to be attributed if no other
+                target function provided
                 A typical example is as follows:
                 ```python
                 def f(params, data):
@@ -65,7 +67,6 @@ class AttributionTask:
                 in terms of what is calculated,
                 but it should take the parameters and the data as input. Other than
                 that, the forwarding of model should be in `torch.func` style.
-                A typical example is as follows:
                 A typical example is as follows:
                 ```python
                 def f(params, data):

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -22,7 +22,7 @@ class AttributionTask:
 
     def __init__(
         self,
-        target_func: Callable,
+        loss_func: Callable,
         model: nn.Module,
         checkpoints: Union[
             str,
@@ -30,11 +30,12 @@ class AttributionTask:
             List[Dict[str, torch.Tensor]],
             Dict[str, torch.Tensor],
         ],
+        target_func: Optional[Callable] = None,
     ) -> None:
         """Initialize the AttributionTask.
 
         Args:
-            target_func (Callable): The target function to be attributed.
+            loss_func (Callable): The loss function of the model training.
                 The function can be quite flexible in terms of what is calculated,
                 but it should take the parameters and the data as input. Other than
                 that, the forwarding of model should be in `torch.func` style.
@@ -58,9 +59,29 @@ class AttributionTask:
                 of the model, both dictionary of the state_dict and the path to
                 the checkpoint are supported. If ensemble is needed, a list of
                 checkpoint is also supported.
+            target_func (Callable): The target function to be attributed.
+                This input is optional, if not provided, the target function will
+                be the same as the loss function. The function can be quite flexible
+                in terms of what is calculated,
+                but it should take the parameters and the data as input. Other than
+                that, the forwarding of model should be in `torch.func` style.
+                A typical example is as follows:
+                A typical example is as follows:
+                ```python
+                def f(params, data):
+                    image, label = data
+                    loss = nn.CrossEntropyLoss()
+                    yhat = torch.func.functional_call(model, params, image)
+                    return loss(yhat, label)
+                ```.
 
         """
         self.model = model
+        if target_func is None:
+            target_func = loss_func
+
+        self.original_loss_func = loss_func
+        self.loss_func = flatten_func(self.model)(loss_func)
         self.original_target_func = target_func
         self.target_func = flatten_func(self.model)(target_func)
 
@@ -74,8 +95,10 @@ class AttributionTask:
         self.current_checkpoint_idx = None
 
         # TODO: Make this more general, that is allow customized kwargs.
-        self.grad_func = vmap(grad(self.target_func), in_dims=(None, 1))
-        self.grad_func_kwargs = None
+        self.grad_loss_func = vmap(grad(self.loss_func), in_dims=(None, 1))
+        self.grad_loss_func_kwargs = {"in_dims": (None, 1)}
+        self.grad_target_func = vmap(grad(self.target_func), in_dims=(None, 1))
+        self.grad_target_func_kwargs = {"in_dims": (None, 1)}
 
     def _load_checkpoints(self, index: int) -> None:
         """This method load the checkpoint at the specified index.
@@ -155,10 +178,10 @@ class AttributionTask:
             error_msg = "layer_name has not been implemented yet."
             raise NotImplementedError(error_msg)
 
-        if self.grad_func_kwargs != {"in_dims": in_dims}:
-            self.grad_func = vmap(grad(self.target_func), in_dims=in_dims)
-            self.grad_func_kwargs = {"in_dims": in_dims}
-        return self.grad_func
+        if self.grad_target_func_kwargs != {"in_dims": in_dims}:
+            self.grad_target_func = vmap(grad(self.target_func), in_dims=in_dims)
+            self.grad_target_func_kwargs = {"in_dims": in_dims}
+        return self.grad_target_func
 
     def get_target_func(
         self,
@@ -185,6 +208,65 @@ class AttributionTask:
         if not flatten:
             return self.original_target_func
         return self.target_func
+
+    def get_grad_loss_func(
+        self,
+        in_dims: Tuple[Union[None, int], ...] = (None, 1),
+        layer_name: Optional[Union[str, List[str]]] = None,
+    ) -> Callable:
+        """Return a function that computes the gradient of the loss function.
+
+        TODO: support partial parameter gradient.
+
+        Args:
+            in_dims (Tuple[Union[None, int], ...]): The input dimensions of the loss
+                function. This should be a tuple of integers and None. The length of the
+                tuple should be the same as the number of inputs of the loss function.
+                If the input is a scalar, the corresponding element should be None.
+                If the input is a tensor, the corresponding element should be the
+                dimension of the tensor.
+            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+
+        Returns:
+            Callable: The function that computes the gradient of the loss function.
+
+        Raises:
+            NotImplementedError: If layer_name is not None.
+        """
+        if layer_name is not None:
+            error_msg = "layer_name has not been implemented yet."
+            raise NotImplementedError(error_msg)
+
+        if self.grad_loss_func_kwargs != {"in_dims": in_dims}:
+            self.grad_loss_func = vmap(grad(self.loss_func), in_dims=in_dims)
+            self.grad_loss_func_kwargs = {"in_dims": in_dims}
+        return self.grad_loss_func
+
+    def get_loss_func(
+        self,
+        flatten: bool = True,
+        layer_name: Optional[Union[str, List[str]]] = None,
+    ) -> Callable:
+        """Return a function that computes the gradient of the loss function.
+
+        TODO: support partial parameter gradient.
+
+        Args:
+            flatten (bool): If True, the loss function will be flattened.
+            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+
+        Returns:
+            Callable: The loss function itself.
+
+        Raises:
+            NotImplementedError: If layer_name is not None.
+        """
+        if layer_name is not None:
+            error_msg = "layer_name has not been implemented yet."
+            raise NotImplementedError(error_msg)
+        if not flatten:
+            return self.original_loss_func
+        return self.loss_func
 
     def get_param(
         self,

--- a/example/cifar2_resnet9/influence_function_noisy_label.py
+++ b/example/cifar2_resnet9/influence_function_noisy_label.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         yhat = torch.func.functional_call(model, params, image)
         return loss(yhat, label.long())
 
-    task = AttributionTask(target_func=f,
+    task = AttributionTask(loss_func=f,
                            model=model,
                            checkpoints=model.state_dict())
 

--- a/example/mnist_lr/influence_function_lds.py
+++ b/example/mnist_lr/influence_function_lds.py
@@ -18,7 +18,7 @@ def f(params, data_target_pair):
 
 task = AttributionTask(
     model=model_details["model"].cuda(),
-    target_func=f,
+    loss_func=f,
     checkpoints=model_details["models_full"][0]  # here we use one full model
 )
 

--- a/example/mnist_lr/influence_function_noisy_label.py
+++ b/example/mnist_lr/influence_function_noisy_label.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         yhat = torch.func.functional_call(model, params, image)
         return loss(yhat, label.long())
 
-    task = AttributionTask(target_func=f,
+    task = AttributionTask(loss_func=f,
                            model=model,
                            checkpoints=model.state_dict())
     attributor = ATTRIBUTOR_MAP[args.method](

--- a/example/mnist_lr/tracin_noisy_label.py
+++ b/example/mnist_lr/tracin_noisy_label.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         return loss(yhat, label_t)
 
     task = AttributionTask(
-        target_func=f,
+        loss_func=f,
         model=model_1,
         checkpoints=model_1.state_dict(),
     )

--- a/example/mnist_lr/trak_noisy_label.py
+++ b/example/mnist_lr/trak_noisy_label.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         p = torch.exp(-loss(yhat, label_t))
         return p
 
-    task = AttributionTask(target_func=f,
+    task = AttributionTask(loss_func=f,
                            model=model,
                            checkpoints=model.state_dict())
 

--- a/test/dattri/algorithm/test_influence_function.py
+++ b/test/dattri/algorithm/test_influence_function.py
@@ -40,7 +40,7 @@ class TestInfluenceFunction:
             return loss(yhat, label.long())
 
         task = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=model.state_dict(),
         )
@@ -113,12 +113,12 @@ class TestInfluenceFunction:
             return loss(yhat, label.long())
 
         task = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=model.state_dict(),
         )
         task_m = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=[model.state_dict(), model.state_dict()],
         )

--- a/test/dattri/algorithm/test_rps.py
+++ b/test/dattri/algorithm/test_rps.py
@@ -56,7 +56,7 @@ class TestRPS:
             return functional.cross_entropy(pre_activation_list, label_list)
 
         task = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=model.state_dict(),
         )
@@ -101,7 +101,7 @@ class TestRPS:
             )
 
         task = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=model.state_dict(),
         )

--- a/test/dattri/algorithm/test_tracin.py
+++ b/test/dattri/algorithm/test_tracin.py
@@ -57,7 +57,7 @@ class TestTracInAttributor:
         checkpoint_list = ["ckpts/model_1.pt", "ckpts/model_2.pt"]
 
         task = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=checkpoint_list,
         )
@@ -127,7 +127,7 @@ class TestTracInAttributor:
         checkpoint_list = ["ckpts/model_1.pt", "ckpts/model_2.pt"]
 
         task = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=checkpoint_list,
         )

--- a/test/dattri/algorithm/test_trak.py
+++ b/test/dattri/algorithm/test_trak.py
@@ -55,12 +55,12 @@ class TestTRAK:
             "use_half_precision": False,
         }
         task = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=["ckpts/model_1.pt"],
         )
         task_m = AttributionTask(
-            target_func=f,
+            loss_func=f,
             model=model,
             checkpoints=checkpoint_list,
         )


### PR DESCRIPTION
## Description

### 1. Motivation and Context
We want to make 2 concepts clearer.

- `loss_func`: the loss function used to train the model to be attributed. Normally, this one is used to estimate the changes of parameter when one data point is up/down weighted (IF style) or between each iterations (TracIN style).
- `target_func`: the target function we want to attribute on. This one is normally set to be the same as loss function but not necessarily to be the same. so we make it optional in `dattri.task.AttributionTask`.

### 2. Summary of the change
1. add `loss_func` in `dattri.task.AttributionTask` and make `target_func` optional.
2. change some internal implementation of `dattri.algorithm` (no API change)

### 3. What tests have been added/updated for the change?
- [ ] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.

