### PR TITLE
[dattri.func] Fix `ChunkedCudaProjector` bug

### DIFF
--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -573,7 +573,7 @@ class ChunkedCudaProjector:
                 ),
             )
 
-        return ch_output[: self.feature_batch_size]
+        return ch_output
 
 
 class ArnoldiProjector(AbstractProjector):

--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -548,7 +548,7 @@ class ChunkedCudaProjector:
         Returns:
             Tensor: The projected features.
         """
-        self.allocate_input()
+        # allocate zero tensor for output
         ch_output = torch.zeros(
             size=(self.feature_batch_size, self.proj_dim),
             device=self.device,
@@ -563,10 +563,12 @@ class ChunkedCudaProjector:
         for chunk_idx, chunk_dim in enumerate(self.dim_per_chunk):
             ch_output.add_(
                 self.projector_per_chunk[chunk_idx].project(
-                    self.ch_input[:, pointer : pointer + chunk_dim].contiguous(),
+                    features[:, pointer : pointer + chunk_dim].contiguous(),
                     ensemble_id=ensemble_id,
                 ),
             )
+
+            pointer += chunk_dim
 
         return ch_output
 

--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -544,11 +544,6 @@ class ChunkedCudaProjector:
                 of batch of features.
             ensemble_id (int): A unique ID for this ensemble.
 
-        Raises:
-            ValueError: The number of accumulated #feature dim does not match
-                dim_per_chunk.
-            ValueError: The number of accumulated #feature dim does not match
-                dim_per_chunk.
 
         Returns:
             Tensor: The projected features.

--- a/dattri/func/utils.py
+++ b/dattri/func/utils.py
@@ -88,7 +88,7 @@ def _vectorize(
     return arr
 
 
-def get_parameter_chunk_sizes(
+def _get_parameter_chunk_sizes(
     param_shape_list: List,
     batch_size: int,
 ) -> tuple[int, int]:
@@ -124,6 +124,38 @@ def get_parameter_chunk_sizes(
 
     if param_shapes.sum() - np.sum(params_per_chunk) > 0:
         params_per_chunk.append(param_shapes.sum() - np.sum(params_per_chunk))
+
+    return max_chunk_size, params_per_chunk
+
+
+def get_parameter_chunk_sizes(
+    param_shape_list: List,
+    batch_size: int,
+) -> tuple[int, int]:
+    """Compute chunk size information from feature to be projected.
+
+    Get a tuple containing max chunk size and a list of the number of
+    parameters in each chunk.
+
+    Args:
+        param_shape_list (List): A list of numbers indicating the total number of
+            features to be projected. A typical example is a list of parameter
+            size of each module in a torch.nn.Module model.
+        batch_size (int): The batch size. Each term (or module) in feature
+            will have the same batch size.
+
+    Returns:
+        tuple[int, int]: Maximum number of parameter per chunk and a list of
+            number of parameters in each chunk.
+    """
+    # get the number of total params
+    param_num = param_shape_list[0]
+
+    max_chunk_size = np.iinfo(np.uint32).max // batch_size
+
+    num_chunk = param_num // max_chunk_size
+    remaining = param_num % max_chunk_size
+    params_per_chunk = [max_chunk_size] * num_chunk + [remaining]
 
     return max_chunk_size, params_per_chunk
 

--- a/test/dattri/func/test_proj.py
+++ b/test/dattri/func/test_proj.py
@@ -497,13 +497,13 @@ class TestGetProjection(unittest.TestCase):
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
     def test_tensor_input_chunked_cuda(self):
         """Test the usage of tensor input."""
-        test_batch_size = 64
-
-        test_tensor = torch.rand(test_batch_size, 300000000)
+        feature_batch_size = 4
+        # 0.3B is slighly larger then max_chunk_size (~0.26B)
+        test_tensor = torch.rand(feature_batch_size, 300000000)
         # suppose to be ChunkedCudaProjector
         project = random_project(
             test_tensor,
-            test_batch_size,
+            feature_batch_size,
             self.proj_dim,
             self.proj_max_batch_size,
             device="cuda",
@@ -512,7 +512,7 @@ class TestGetProjection(unittest.TestCase):
         )
 
         result = project(test_tensor)
-        assert result.shape == (test_batch_size, self.proj_dim)
+        assert result.shape == (feature_batch_size, self.proj_dim)
 
     def test_arnoldi_project(self):
         """Test the funcitonality of arnoldi_project."""

--- a/test/dattri/func/test_proj.py
+++ b/test/dattri/func/test_proj.py
@@ -480,7 +480,27 @@ class TestGetProjection(unittest.TestCase):
         test_batch_size = 64
 
         test_tensor = torch.rand(test_batch_size, 1000)
-        # suppose to be BasicProjector
+        # suppose to be CudaProjector
+        project = random_project(
+            test_tensor,
+            test_batch_size,
+            self.proj_dim,
+            self.proj_max_batch_size,
+            device="cuda",
+            proj_seed=0,
+            use_half_precision=True,
+        )
+
+        result = project(test_tensor)
+        assert result.shape == (test_batch_size, self.proj_dim)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+    def test_tensor_input_chunked_cuda(self):
+        """Test the usage of tensor input."""
+        test_batch_size = 64
+
+        test_tensor = torch.rand(test_batch_size, 300000000)
+        # suppose to be ChunkedCudaProjector
         project = random_project(
             test_tensor,
             test_batch_size,


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context
We found that `ChunkedCudaProjector` not working as expected for large models. For Dict input, we found it hard to project without dividing gradients, so we will inherently force dict input to be tensor and split the tensor for projection if it is too large.
<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

### 2. Summary of the change
- fix chunkcudaprojector bug by forcing tensor input
- add chunkcudaprojector test case for tensor input

Note that I preserve most of the original code and possibly we can come back and make it support dict input (without enforcing it to be tensor).
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. What tests have been added/updated for the change?
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.