### PR TITLE
[dattri.metrics] Add brittleness test

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ model = activate_dropout(model, ["dropout1", "dropout2"], dropout_prob=0.2)
 - Leave-one-out (LOO) correlation
 - Linear datamodeling score (LDS)
 - Area under the ROC curve (AUC) for noisy label detection
+- Brittleness test for checking flipped label
 
 ## Benchmark Settings Supported
 |   Dataset   |       Model       |         Task         | Sample size (train,test) | Parameter size |   Metrics   |          Data Source         |

--- a/dattri/metrics/britteness.py
+++ b/dattri/metrics/britteness.py
@@ -105,12 +105,12 @@ def check_if_flip(
         sampler=SubsetSampler(remaining_indices),
     )
 
-    model = train_func(new_train_loader, device=device)
+    model = train_func(new_train_loader)
     model.to(device)
     model.eval()
 
     for test_data in test_loader:
         x, label = test_data
         x, label = x.to(device), label.to(device)
-    pred = eval_func(model, test_loader, device=device)
+    pred = eval_func(model, test_loader)
     return pred.item() != label.item()

--- a/dattri/metrics/britteness.py
+++ b/dattri/metrics/britteness.py
@@ -1,0 +1,115 @@
+"""This module provides britteness prediction evaluate the data attribution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Subset
+from tqdm import tqdm
+
+
+def brittleness(
+    test_data: Tuple[torch.Tensor, torch.Tensor],
+    train_loader: DataLoader,
+    train_data_indices: torch.Tensor,
+    scores: torch.Tensor,
+    steplength: Tuple[int, int, int],
+    train_func: Callable[[DataLoader], torch.nn.Module],
+    device: torch.device,
+    batch_size: int = 64,
+) -> Optional[int]:
+    """Calculate smallest k make a test data flip.
+
+    This function calculate the brittleness metric by determining the smallest subset of
+    training data whose removal causes the test sample's prediction to flip.
+
+    Args:
+        test_data (tuple): A tuple containing the image and label of the test sample.
+        train_loader (DataLoader): DataLoader for the training data.
+        train_data_indices (list[int]): Indices of the training data used.
+        scores (torch.Tensor):
+            Data attribution scores associated with each training sample.
+        steplength (tuple): Tuple containing start, end, and step size for the k range.
+        train_func (function): Function to retrain the model on the modified dataset.
+        device (torch.device): The device (CPU or GPU) to perform computations on.
+        batch_size (int):
+            The batch size used when creating new DataLoaders. Default is 64.
+
+    Returns:
+        int or None: The smallest number of influential training points whose removal
+        flips the test point's prediction, or None if no such k exists.
+    """
+    start, end, step = steplength
+    k_values = list(range(start, end, step))
+    if isinstance(scores, torch.Tensor):
+        scores = scores.cpu().numpy() if scores.is_cuda else scores.numpy()
+    sorted_indices = np.argsort(scores)[::-1]
+    for k in tqdm(
+        k_values,
+        desc="Calculating brittleness",
+        leave=False,
+        ):
+        highest_score_indices = sorted_indices[:k]
+        if check_if_flip(test_data,
+                         train_loader,
+                         train_data_indices,
+                         highest_score_indices,
+                         train_func,
+                         device,
+                         batch_size):
+            return k
+    return None
+
+
+def check_if_flip(
+    test_data: Tuple[torch.Tensor, torch.Tensor],
+    train_loader: DataLoader,
+    train_data_indices: List[int],
+    indices_to_remove: List[int],
+    train_func: Callable[[DataLoader], torch.nn.Module],
+    device: torch.device,
+    batch_size: int,
+) -> bool:
+    """Flip check for brittleness prediction.
+
+    This function weill check if the prediction for a test sample flips after
+    removing certain training data.
+
+    Args:
+        test_data (tuple): The test data consisting of an image and its label.
+        train_loader (DataLoader): DataLoader for the training data.
+        train_data_indices (list[int]):
+            List of indices indicating orignial data the used training data.
+        indices_to_remove (list[int]):
+            Indices of the training data to remove.
+        train_func (function): Function to train the model on the modified dataset.
+        device (torch.device): The device for computation.
+        batch_size (int): Batch size for the DataLoader of the new training set.
+
+    Returns:
+        bool: True if the prediction flips, otherwise False.
+    """
+    dataset = train_loader.dataset
+    dataset = Subset(dataset, train_data_indices)
+
+    remaining_indices = list(set(range(len(dataset))) - set(indices_to_remove))
+    subset = Subset(dataset, remaining_indices)
+    new_train_loader = DataLoader(subset, batch_size=batch_size, shuffle=True)
+
+    model = train_func(new_train_loader)
+    model.to(device)
+    model.eval()
+
+    x, label = test_data
+    x, label = x.to(device), label.to(device)
+
+    output = model(x)
+    pred = output.argmax(dim=1, keepdim=True)
+
+    return pred.item() != label.item()

--- a/dattri/metrics/britteness.py
+++ b/dattri/metrics/britteness.py
@@ -101,16 +101,16 @@ def check_if_flip(
 
     new_train_loader = torch.utils.data.DataLoader(
         train_loader.dataset,
-        batch_size=64,
+        batch_size=train_loader.batch_size,
         sampler=SubsetSampler(remaining_indices),
     )
 
-    model = train_func(new_train_loader,device = device)
+    model = train_func(new_train_loader, device=device)
     model.to(device)
     model.eval()
 
     for test_data in test_loader:
         x, label = test_data
         x, label = x.to(device), label.to(device)
-    pred = eval_func(model, test_loader, device = device)
+    pred = eval_func(model, test_loader, device=device)
     return pred.item() != label.item()

--- a/dattri/metrics/britteness.py
+++ b/dattri/metrics/britteness.py
@@ -36,8 +36,9 @@ def brittleness(
         test_loader (DataLoader): DataLoader for test data.
         scores (torch.Tensor):
             Attribution scores in shape (len(train_loader), len(test_loader)).
-        train_func (function): Function to retrain the model on modified dataset.
-        eval_func (function): Function to evaluate the model and return predictions.
+        train_func (Callable[[DataLoader], torch.nn.Module]):
+            Function to retrain the model on modified dataset.
+        eval_func (Callable): Function to evaluate the model and return predictions.
         device (torch.device): Computation device (CPU or GPU).
         search_space (List[int]):
             List of points in the search space for most influential training data.
@@ -82,8 +83,9 @@ def check_if_flip(
         train_loader (DataLoader): DataLoader for the training data.
         test_loader (DataLoader): DataLoader for test data.
         indices_to_remove (List[int]): Indices of training data to remove.
-        train_func (function): Function to retrain the model on modified dataset.
-        eval_func (function): Function to evaluate the model and return predictions.
+        train_func (Callable[[DataLoader], torch.nn.Module]):
+            Function to retrain the model on modified dataset.
+        eval_func (Callable): Function to evaluate the model and return predictions.
         device (torch.device): Computation device.
 
     Returns:

--- a/experiments/mnist_lr_brittleness.py
+++ b/experiments/mnist_lr_brittleness.py
@@ -117,10 +117,20 @@ if __name__ == "__main__":
     start_time = time.time()
 
     # Evaluation 
-    def eval_func(model_output):
-        probabilities = torch.softmax(model_output, dim=1)
-        predicted_class = torch.argmax(probabilities, dim=1)
-        return predicted_class
+    def eval_func(model, test_loader, device= "cpu"):
+        model.to(device)
+        model.eval()
+        all_predictions = []
+
+        with torch.no_grad():
+            for data, _ in test_loader:
+                data = data.to(device)
+                model_output = model(data)
+                probabilities = torch.softmax(model_output, dim=1)
+                predicted_class = torch.argmax(probabilities, dim=1)
+                all_predictions.append(predicted_class.cpu())
+
+        return torch.cat(all_predictions)
 
     smallest_k = brittleness(
         train_loader=train_loader,

--- a/experiments/mnist_lr_brittleness.py
+++ b/experiments/mnist_lr_brittleness.py
@@ -1,7 +1,4 @@
 """This experiment brittleness TDA methods on the MNIST-10 dataset."""
-import sys
-sys.path.append('/home/sz54/dattri_1/')
-
 # ruff: noqa
 import time
 import argparse
@@ -18,7 +15,6 @@ from dattri.algorithm.influence_function import\
     IFAttributorDataInf,\
     IFAttributorArnoldi
 from dattri.benchmark.datasets.mnist import train_mnist_lr, create_mnist_dataset
-from dattri.benchmark.utils import flip_label
 from dattri.benchmark.utils import SubsetSampler
 from dattri.metrics.britteness import brittleness
 from dattri.task import AttributionTask

--- a/experiments/mnist_lr_brittleness.py
+++ b/experiments/mnist_lr_brittleness.py
@@ -1,0 +1,138 @@
+"""This experiment is for brittleness test on Influence Function on the MNIST-10 dataset."""
+
+# ruff: noqa
+import time
+import argparse
+from functools import partial
+
+import numpy as np
+import torch
+from tqdm import tqdm
+from torch import nn
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader, Subset
+
+from dattri.algorithm.influence_function import\
+    IFAttributorExplicit,\
+    IFAttributorCG,\
+    IFAttributorLiSSA,\
+    IFAttributorDataInf,\
+    IFAttributorArnoldi
+from dattri.benchmark.datasets.mnist import train_mnist_lr, create_mnist_dataset
+from dattri.benchmark.utils import flip_label
+from dattri.benchmark.utils import SubsetSampler
+from dattri.metrics.britteness import brittleness
+from dattri.task import AttributionTask
+
+ATTRIBUTOR_MAP = {
+    "explicit": partial(IFAttributorExplicit, regularization=0.01),
+    "cg": partial(IFAttributorCG, regularization=0.01),
+    "lissa": partial(IFAttributorLiSSA, recursion_depth=100),
+    "datainf": partial(IFAttributorDataInf, regularization=0.01),
+    "arnoldi": partial(IFAttributorArnoldi, regularization=0.01, max_iter=10)
+}
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--method", type=str, default="explicit")
+    parser.add_argument("--device", type=str, default="cuda")
+    args = parser.parse_args()
+
+    dataset, _ = create_mnist_dataset("./data")
+
+    # for model training
+    train_loader_full = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=64,
+        sampler=SubsetSampler(range(1000)),
+    )
+    # training samples for attribution
+    train_loader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=500,
+        sampler=SubsetSampler(range(1000)),
+    )
+    
+    # test samples for attribution
+    test_loader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=500,
+        sampler=SubsetSampler(range(1000)),
+    )
+
+    model = train_mnist_lr(train_loader_full)
+    model.cuda()
+    model.eval()
+
+    
+    def f(params, data_target_pair):
+        image, label = data_target_pair
+        loss = nn.CrossEntropyLoss()
+        yhat = torch.func.functional_call(model, params, image)
+        return loss(yhat, label.long())
+
+    task = AttributionTask(target_func=f,
+                           model=model,
+                           checkpoints=model.state_dict())
+    attributor = ATTRIBUTOR_MAP[args.method](
+        task=task,
+        device=args.device,
+    )
+
+    attributor.cache(train_loader_full)
+    torch.cuda.reset_peak_memory_stats("cuda")
+    with torch.no_grad():
+        score = attributor.attribute(train_loader, test_loader)
+
+    model = train_mnist_lr(train_loader)
+    model.cuda()
+    model.eval()
+    correct_x = None
+    correct_label = None
+    correct_index = None
+
+    # Find a correct predicted data
+    for test_batch in test_loader:
+        for i in range(len(test_batch[0])):
+            x = test_batch[0][i].unsqueeze(0).cuda()
+            label = test_batch[1][i].cuda()
+            output = model(x)
+            pred = output.argmax(dim=1, keepdim=True)
+
+            if pred.item() == label.item():
+                print(f"Found a correctly predicted test sample with correct index is: {i}")
+                print(f"The label: {label.item()}, the prediction: {pred.item()}")
+                correct_x = x
+                correct_label = label
+                correct_index = i
+                break
+
+        if correct_x is not None:
+            break
+    
+    # Example test sample
+    test_data = (correct_x, correct_label)
+    score = score[:, correct_index]
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Compute brittleness
+    start_time = time.time()
+
+    smallest_k = brittleness(
+        test_data=test_data,
+        train_loader=train_loader,
+        train_data_indices=torch.tensor(range(1000)),
+        scores=score,
+        steplength=(20, 200, 20),
+        train_func=lambda loader: train_mnist_lr(loader),
+        device=device
+    )
+
+    if smallest_k is not None:
+        print(f"The number of removal that can make it flip: {smallest_k}")
+    else:
+        print("No k found that causes a flip.")
+    end_time = time.time()
+    print("Total time for brittleness test: ", end_time - start_time)
+    


### PR DESCRIPTION
## Description

### 1. Motivation and Context

This PR is to add brittleness test in metrics. [Reference paper](https://arxiv.org/pdf/2202.00622). This version does not use interpolate.

### 2. Summary of the change

1. Add brittleness.py under metrics. (After review, we may make it wrapped as a function in metric.py.
2. Add mnist_lr_brittleness.py in experiment folder to show how to use this metric to evaluate Influence Function.

### 3. What tests have been added/updated for the change?
 N/A: 

