### PR TITLE
[Doc] Quick fix on the document about `__init__` methods' correct presentation.

### DIFF
--- a/docs/source/api/algorithm.rst
+++ b/docs/source/api/algorithm.rst
@@ -2,18 +2,22 @@ Attributors
 =======
 .. automodule:: dattri.algorithm.influence_function
     :members:
+    :special-members: __init__
     :undoc-members:
     :show-inheritance:
     :inherited-members:
 .. autoclass:: dattri.algorithm.tracin.TracInAttributor
     :members:
+    :special-members: __init__
     :undoc-members:
     :show-inheritance:
 .. autoclass:: dattri.algorithm.trak.TRAKAttributor
     :members:
+    :special-members: __init__
     :undoc-members:
     :show-inheritance:
 .. autoclass:: dattri.algorithm.rps.RPSAttributor
     :members:
+    :special-members: __init__
     :undoc-members:
     :show-inheritance:

--- a/docs/source/api/task.rst
+++ b/docs/source/api/task.rst
@@ -2,5 +2,6 @@ Tasks
 =======
 .. autoclass:: dattri.task.AttributionTask
     :members:
+    :special-members: __init__
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
## Description

This a quick fix to make `__init__` shown in our document.