### PR TITLE
[dattri.task] add partial parameter support for target/loss function and their gradient func

### DIFF
--- a/test/dattri/test_task.py
+++ b/test/dattri/test_task.py
@@ -1,0 +1,50 @@
+"""Test for influence function."""
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from dattri.benchmark.datasets.mnist import train_mnist_mlp
+from dattri.task import AttributionTask
+
+
+class TestTask:
+    """Test for AttributionTask."""
+
+    def test_task_partial(self):
+        """Test for partial parameter."""
+        train_dataset = TensorDataset(
+            torch.randn(20, 1, 28, 28),
+            torch.randint(0, 10, (20,)),
+        )
+        train_loader = DataLoader(train_dataset, batch_size=4)
+        model = train_mnist_mlp(train_loader)
+
+        def f(params, data_target_pair):
+            image, label = data_target_pair
+            loss = nn.CrossEntropyLoss()
+            yhat = torch.func.functional_call(model, params, image)
+            return loss(yhat, label.long())
+
+        task = AttributionTask(loss_func=f, model=model, checkpoints=model.state_dict())
+
+        grad_func_partial = task.get_grad_loss_func(
+            layer_name=["fc3.weight", "fc3.bias"],
+            index=0,
+        )
+        grad_func_full = task.get_grad_loss_func()
+
+        for train_batch_data_ in train_loader:
+            train_batch_data = tuple(data.unsqueeze(0) for data in train_batch_data_)
+            params_partial, _ = task.get_param(
+                index=0,
+                layer_name=["fc3.weight", "fc3.bias"],
+            )
+            params_full, _ = task.get_param(index=0)
+            gradient_partial = grad_func_partial(params_partial, train_batch_data)
+            gradient_full = grad_func_full(params_full, train_batch_data)
+            gradient_partial = torch.cat(gradient_partial, dim=1)
+            assert torch.allclose(
+                gradient_partial,
+                gradient_full[:, -gradient_partial.size(1) :],
+            )


### PR DESCRIPTION
## Description

### 1. Motivation and Context
1. This PR supports some extensive requirements for calculating the loss/target function and their grad/hessian based on only a portion of the parameter (e.g., some specific layers).
2. The support should be completely wrapped inside the task abstraction.

### 2. Summary of the change
1. Support the `layer_name` for `task.get_grad_target_func`, `task.get_target_func`, `task.get_grad_loss_func`, and `task.get_loss_func` (previously it will raise a notimplemented error).

TODO: this is the first PR to support partial parameter in dattri. Next PRs will support this feature in high-level attributor APIs.

```python
task = AttributionTask(loss_func=f, model=model, checkpoints=model.state_dict())

# only use the last layer's parameter
grad_func_partial = task.get_grad_loss_func(
    layer_name=["fc3.weight", "fc3.bias"],
    index=0,  # this is a special additional parameter, because some other parameters we need to copy from the checkpoint.
)
params_partial, _ = task.get_param(
    layer_name=["fc3.weight", "fc3.bias"],
    index=0,
)
gradient_partial = grad_func_partial(params_partial, data_pair)

# only use the full parameter
grad_func_full = task.get_grad_loss_func()
params_full, _ = task.get_param()
gradient_full = grad_func_full(params_full, data_pair)

# the last layer's parameter's gradient should be the same as the last few dim full parameter's gradient.
torch.all_close(gradient_full[-last_layer_index:], gradient_partial)

```

### 3. What tests have been added/updated for the change?
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
