### PR TITLE
[dattri.algorithm] Add KNN data shapley

### DIFF
--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -40,7 +40,7 @@ def default_dist_func(
 
 
 class KNNShalpeyAttributor(BaseAttributor):
-    """KNN Data Shapley Attributer."""
+    """KNN Data Shapley Attributor."""
 
     def __init__(
         self,

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import List
+    from typing import List, Optional, Tuple
 
 import torch
 from tqdm import tqdm
@@ -15,9 +15,22 @@ from .base import BaseAttributor
 from .utils import _check_shuffle
 
 
-def default_dist_func(train_batch, test_batch):
-    coord1 = train_batch[0]
-    coord2 = test_batch[0]
+def default_dist_func(
+        batch_x: Tuple[torch.Tensor],
+        batch_y: Tuple[torch.Tensor],
+) -> torch.Tensor:
+    """Default distance function for KNN.
+
+    Args:
+        batch_x (Tuple[torch.Tensor]): The batch to be calculated
+            distances on. The embeddings is default to be the
+            first element.
+        batch_y (Tuple[torch.Tensor]): The batch to be calculated
+            distances on. The embeddings is default to be the
+            first element.
+    """
+    coord1 = batch_x[0]
+    coord2 = batch_y[0]
     return torch.cdist(coord1, coord2)
 
 
@@ -27,7 +40,7 @@ class KNNShalpeyAttributerExact(BaseAttributor):
     def __init__(
         self,
         k_neighbors: int,
-        distance_func: Callable = None,
+        distance_func: Optional[Callable] = None,
     ) -> None:
         """Initialize the AttributionTask.
 
@@ -37,17 +50,19 @@ class KNNShalpeyAttributerExact(BaseAttributor):
 
         Args:
             k_neighbors (int): The number of neighbors in KNN model.
-            distance_func (Callable): Customizable function used for
-                distance calculation in KNN. The function can be quite
-                flexible in terms of what is calculated, but it should
-                take two batches of data as input.
+            distance_func (Callable, optional): Customizable function
+                used for distance calculation in KNN. The function
+                can be quite flexible in terms of what is calculated,
+                but it should take two batches of data as input.
                 A typical example is as follows:
                 ```python
-                def f(train_batch, test_batch):
-                    coord1 = train_batch[0]
-                    coord2 = test_batch[0]
+                def f(batch_x, batch_y):
+                    coord1 = batch_x[0]
+                    coord2 = batch_y[0]
                     return torch.cdist(coord1, coord2)
                 ```.
+                If not provided, a default Euclidean distance function
+                will be used.
         """
         self.k_neighbors = k_neighbors
 

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -72,6 +72,9 @@ class KNNShalpeyAttributor(BaseAttributor):
                 ```.
                 If not provided, a default Euclidean distance function
                 will be used.
+
+        Raises:
+            NotImplementedError: If task is not None.
         """
         self.k_neighbors = k_neighbors
 

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -37,7 +37,7 @@ def default_dist_func(
     return torch.cdist(coord1, coord2)
 
 
-class KNNShalpeyAttributerExact(BaseAttributor):
+class KNNShalpeyAttributor(BaseAttributor):
     """KNN Data Shapley Attributer."""
 
     def __init__(

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -1,0 +1,135 @@
+"""This module implement data shapley valuation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import List
+
+import torch
+from tqdm import tqdm
+
+from .base import BaseAttributor
+from .utils import _check_shuffle
+
+
+class KNNShalpeyAttributerExact(BaseAttributor):
+    """KNN Data Shapley Attributer."""
+
+    def __init__(
+        self,
+        k: int,
+        distance_func: Callable,
+    ) -> None:
+        """Initialize the AttributionTask.
+
+        KNN Data Shapley Valuation is task-agnostic.
+
+        Args:
+            k (int): The number of neighbors in KNN model.
+            distance_func (Callable): Customizable function used for
+                distance calculation in KNN. The function can be quite
+                flexible in terms of what is calculated, but it should
+                take two batches of data as input.
+                A typical example is as follows:
+                ```python
+                def f(train_batch, test_batch):
+                    coord1 = train_batch[0]
+                    coord2 = test_batch[0]
+                    return torch.cdist(coord1, coord2)
+                ```.
+        """
+        self.k = k
+        self.distance_func = distance_func
+
+    def cache(self) -> None:
+        """Precompute and cache some values for efficiency."""
+
+    def attribute(
+        self,
+        train_dataloader: torch.utils.data.DataLoader,
+        test_dataloader: torch.utils.data.DataLoader,
+        train_labels: List[int],
+        test_labels: List[int],
+    ) -> None:
+        """Calculate the shapley values of the training set on each test sample.
+
+        Args:
+            train_dataloader (torch.utils.data.DataLoader): The dataloader for
+                training samples to calculate the shapley values. The dataloader
+                should not be shuffled.
+            test_dataloader (torch.utils.data.DataLoader): The dataloader for
+                test samples to calculate the shapley values. The dataloader
+                should not be shuffled.
+            train_labels: (List[int]): The list of training labels, with the same
+                size and order of the training dataset.
+            test_labels: (List[int]): The list of test labels, with the same
+                size and order of the test dataset.
+
+        Returns:
+            Tensor: The shapley values of the training set on the test set, with
+                the shape of (num_train_samples, num_test_samples).
+        """
+        _check_shuffle(test_dataloader)
+        _check_shuffle(train_dataloader)
+
+        num_train_samples = len(train_dataloader.sampler)
+        num_test_samples = len(test_dataloader.sampler)
+
+        dist_matrix = torch.zeros(
+            size=(num_test_samples, num_train_samples),
+        )
+
+        shapley_values = torch.zeros(
+            size=(num_test_samples, num_train_samples),
+        )
+
+        for test_batch_idx, test_batch_data in enumerate(
+            tqdm(
+                test_dataloader,
+                desc="fitting KNN...",
+                leave=False,
+            ),
+        ):
+            for train_batch_idx, train_batch_data in enumerate(
+                train_dataloader,
+            ):
+                partial_dist = self.distance_func(test_batch_data, train_batch_data)
+
+                # results position based on batch info
+                col_st = train_batch_idx * train_dataloader.batch_size
+                col_ed = min(
+                    (train_batch_idx + 1) * train_dataloader.batch_size,
+                    len(train_dataloader.sampler),
+                )
+
+                row_st = test_batch_idx * test_dataloader.batch_size
+                row_ed = min(
+                    (test_batch_idx + 1) * test_dataloader.batch_size,
+                    len(test_dataloader.sampler),
+                )
+
+                dist_matrix[row_st:row_ed, col_st:col_ed] += partial_dist
+
+        nn_sorting = torch.argsort(dist_matrix, dim=-1)
+
+        # Recursive calculation of shapley values
+        for j in tqdm(
+            range(num_test_samples),
+            desc="calculating shapley values...",
+            leave=False,
+        ):
+            shapley_values[j, nn_sorting[j, -1]] = (
+                train_labels[nn_sorting[j, -1]] == test_labels[j]
+            ) / num_train_samples
+
+            for i in torch.arange(num_train_samples - 2, -1, -1):
+                shapley_values[j, nn_sorting[j, i]] = \
+                    shapley_values[j, nn_sorting[j, i + 1]] + \
+                    (int(train_labels[nn_sorting[j, i]] == test_labels[j]) -
+                    int(train_labels[nn_sorting[j, i + 1]] == test_labels[j])) \
+                    / self.k * min([self.k, i + 1]) / (i + 1)
+
+        return shapley_values

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -177,6 +177,8 @@ class KNNShalpeyAttributor(BaseAttributor):
 
                 dist_matrix[row_st:row_ed, col_st:col_ed] += partial_dist
 
+                # Take the last element of the batch as the label
+                # If no labels are provided.
                 if len(train_labels) != len(train_dataloader.sampler):
                     train_labels.extend(train_batch_data[-1])
 

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -114,7 +114,7 @@ class KNNShalpeyAttributor(BaseAttributor):
                 the last element in each batch from the loader will be used as label.
 
         Returns:
-            Tensor: The shapley values of the training set on the test set, with
+            Tensor: The KNN shapley values of the training set on the test set, with
                 the shape of (num_train_samples, num_test_samples).
 
         Raises:

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import List, Optional, Tuple
 
+    from dattri.task import AttributionTask
+
 import torch
 from tqdm import tqdm
 
@@ -43,6 +45,7 @@ class KNNShalpeyAttributor(BaseAttributor):
     def __init__(
         self,
         k_neighbors: int,
+        task: AttributionTask = None,
         distance_func: Optional[Callable] = None,
     ) -> None:
         """Initialize the AttributionTask.
@@ -53,6 +56,9 @@ class KNNShalpeyAttributor(BaseAttributor):
 
         Args:
             k_neighbors (int): The number of neighbors in KNN model.
+            task (AttributionTask): The task to be attributed. Used to
+                pass the model and hook information in this attributor.
+                Please refer to the `AttributionTask` for more details.
             distance_func (Callable, optional): Customizable function
                 used for distance calculation in KNN. The function
                 can be quite flexible in terms of what is calculated,
@@ -69,8 +75,13 @@ class KNNShalpeyAttributor(BaseAttributor):
         """
         self.k_neighbors = k_neighbors
 
+        if task is not None:
+            error_msg = ("Specifying the model via the task argument "
+                         "is not implmented yet.")
+            raise NotImplementedError(error_msg)
+
         self.distance_func = default_dist_func
-        if distance_func:
+        if distance_func is not None:
             self.distance_func = distance_func
 
     def cache(self) -> None:

--- a/dattri/algorithm/data_shapley.py
+++ b/dattri/algorithm/data_shapley.py
@@ -28,6 +28,9 @@ def default_dist_func(
         batch_y (Tuple[torch.Tensor]): The batch to be calculated
             distances on. The embeddings is default to be the
             first element.
+
+    Returns:
+        Tensor: The calculated Euclidean distance.
     """
     coord1 = batch_x[0]
     coord2 = batch_y[0]

--- a/test/dattri/algorithm/test_data_shapley.py
+++ b/test/dattri/algorithm/test_data_shapley.py
@@ -9,7 +9,7 @@ from dattri.algorithm.data_shapley import KNNShalpeyAttributerExact
 class TestInfluenceFunction:
     """Test for data shapley."""
 
-    def test_knn_data_shapley_exact():
+    def test_knn_data_shapley_exact(self):
         """Test for exact KNN data shpaley."""
         train_dataset = TensorDataset(
             torch.randn(20, 1, 28, 28),

--- a/test/dattri/algorithm/test_data_shapley.py
+++ b/test/dattri/algorithm/test_data_shapley.py
@@ -28,8 +28,8 @@ class TestInfluenceFunction:
             coord2 = test_batch[0].reshape(-1, 28 * 28)
             return torch.cdist(coord1, coord2)
 
-        attributer = KNNShalpeyAttributor(k_neighbors=3, distance_func=f)
-        sv = attributer.attribute(train_loader,
+        attributor = KNNShalpeyAttributor(k_neighbors=3, distance_func=f)
+        sv = attributor.attribute(train_loader,
                                   test_loader,
                                   train_dataset.tensors[1],
                                   test_dataset.tensors[1])
@@ -44,7 +44,7 @@ class TestInfluenceFunction:
             train_dataset.tensors[1][permutation],
         )
         train_loader_perm = DataLoader(train_dataset_perm, batch_size=4)
-        sv_perm = attributer.attribute(train_loader_perm,
+        sv_perm = attributor.attribute(train_loader_perm,
                                        test_loader,
                                        train_dataset_perm.tensors[1],
                                        test_dataset.tensors[1])

--- a/test/dattri/algorithm/test_data_shapley.py
+++ b/test/dattri/algorithm/test_data_shapley.py
@@ -1,0 +1,52 @@
+"""Test for data shapley."""
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from dattri.algorithm.data_shapley import KNNShalpeyAttributerExact
+
+
+class TestInfluenceFunction:
+    """Test for data shapley."""
+
+    def test_knn_data_shapley_exact():
+        """Test for exact KNN data shpaley."""
+        train_dataset = TensorDataset(
+            torch.randn(20, 1, 28, 28),
+            torch.randint(0, 10, (20,)),
+        )
+        test_dataset = TensorDataset(
+            torch.randn(10, 1, 28, 28),
+            torch.randint(0, 10, (10,)),
+        )
+
+        train_loader = DataLoader(train_dataset, batch_size=4)
+        test_loader = DataLoader(test_dataset, batch_size=2)
+
+        def f(train_batch, test_batch):
+            coord1 = train_batch[0].reshape(-1, 28 * 28)
+            coord2 = test_batch[0].reshape(-1, 28 * 28)
+            return torch.cdist(coord1, coord2)
+
+        attributer = KNNShalpeyAttributerExact(k=3, distance_func=f)
+        sv = attributer.attribute(train_loader,
+                                  test_loader,
+                                  train_dataset.tensors[1],
+                                  test_dataset.tensors[1])
+
+        # Permute train dataset and reproduce the results
+        permutation = torch.randperm(train_dataset.tensors[0].size(0))
+        inverse_permutation = torch.empty_like(permutation)
+        inverse_permutation[permutation] = torch.arange(permutation.size(0))
+
+        train_dataset_perm = TensorDataset(
+            train_dataset.tensors[0][permutation],
+            train_dataset.tensors[1][permutation],
+        )
+        train_loader_perm = DataLoader(train_dataset_perm, batch_size=4)
+        sv_perm = attributer.attribute(train_loader_perm,
+                                       test_loader,
+                                       train_dataset_perm.tensors[1],
+                                       test_dataset.tensors[1])
+        sv_perm = sv_perm[:, inverse_permutation]
+        assert torch.allclose(sv, sv_perm)

--- a/test/dattri/algorithm/test_data_shapley.py
+++ b/test/dattri/algorithm/test_data_shapley.py
@@ -3,7 +3,7 @@
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
-from dattri.algorithm.data_shapley import KNNShalpeyAttributerExact
+from dattri.algorithm.data_shapley import KNNShalpeyAttributor
 
 
 class TestInfluenceFunction:
@@ -28,7 +28,7 @@ class TestInfluenceFunction:
             coord2 = test_batch[0].reshape(-1, 28 * 28)
             return torch.cdist(coord1, coord2)
 
-        attributer = KNNShalpeyAttributerExact(k=3, distance_func=f)
+        attributer = KNNShalpeyAttributor(k=3, distance_func=f)
         sv = attributer.attribute(train_loader,
                                   test_loader,
                                   train_dataset.tensors[1],

--- a/test/dattri/algorithm/test_data_shapley.py
+++ b/test/dattri/algorithm/test_data_shapley.py
@@ -28,7 +28,7 @@ class TestInfluenceFunction:
             coord2 = test_batch[0].reshape(-1, 28 * 28)
             return torch.cdist(coord1, coord2)
 
-        attributer = KNNShalpeyAttributor(k=3, distance_func=f)
+        attributer = KNNShalpeyAttributor(k_neighbors=3, distance_func=f)
         sv = attributer.attribute(train_loader,
                                   test_loader,
                                   train_dataset.tensors[1],


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context

To include the data shapley methods as attribution methods as a completion of the attribution algorithms. Data shapley methods are game-theoretic methods that assign the "relative value of data". This PR focuses on the data shapley values related to KNN.

<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

### 2. Summary of the change

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

1. Add new file `dattri.algorithm.data_shapley` and `KNNShalpeyAttributerExact` as the first data shapley value attributer.
2. Add test case for `KNNShalpeyAttributerExact`.

### 3. What tests have been added/updated for the change?
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
