### PR TITLE
Improve docstring in dattri.func and dattri.metrics

### DIFF
--- a/dattri/func/fisher.py
+++ b/dattri/func/fisher.py
@@ -46,7 +46,7 @@ def ifvp_explicit(
             a single-element Tensor. The FIM will be calculated based on
             this function. Notably, this function should be negative log-likelihood
             (e.g., cross-entropy loss) for classification tasks. If you want to
-            calculate the emperial FIM, you should use the groundtruth label for
+            calculate the empirical FIM, you should use the ground truth label for
             the loss. If you want to calculate the true FIM, you should use the
             predicted label for the loss.
         argnums (int): An integer default to 0. Specifies which argument of func
@@ -102,7 +102,7 @@ def ifvp_at_x_explicit(
             a single-element Tensor. The FIM will be calculated based on
             this function. Notably, this function should be negative log-likelihood
             (e.g., cross-entropy loss) for classification tasks. If you want to
-            calculate the emperial FIM, you should use the groundtruth label for
+            calculate the empirical FIM, you should use the ground truth label for
             the loss. If you want to calculate the true FIM, you should use the
             predicted label for the loss.
         *x: List of arguments for `func`.
@@ -166,10 +166,10 @@ def ifvp_datainf(
             to (0,None,0).
         regularization (List [float]): A float or list of floats default to 0.0.
             Specifies the
-            regularization term to be added to the Hessian matrix in each layer.
-            This is useful when the Hessian matrix is singular or ill-conditioned.
+            regularization term to be added to the empirical FIM in each layer.
+            This is useful when the empirical FIM is singular or ill-conditioned.
             The regularization term is `regularization * I`, where `I` is the
-            identity matrix directly added to the Hessian matrix. The list is
+            identity matrix directly added to the empirical FIM. The list is
             of length L, where L is the total number of layers.
         param_layer_map: Optional[List[int]]: Specifies how the parameters are grouped
             into layers. Should be the same length as parameters tuple. For example,
@@ -178,8 +178,8 @@ def ifvp_datainf(
 
     Returns:
         A function that takes a list of tuples of Tensor `x` and a tuple of tensors
-        `v`(layer-wise) and returns the approximated IFVP of the approximated Hessian of
-        `func` and `v`.
+        `v` (layer-wise) and returns the approximate IFVP of the approximate Hessian
+        of `func` and `v`.
 
     Raises:
         IFVPUsageError: If the length of regularization is not the same as the number
@@ -283,10 +283,10 @@ def ifvp_at_x_datainf(
             batched layer-wise gradients. Example: inputs, weights, labels corresponds
             to (0,None,0).
         regularization (List [float]): A list of floats default to 0.0. Specifies the
-            regularization term to be added to the Hessian matrix in each layer.
-            This is useful when the Hessian matrix is singular or ill-conditioned.
+            regularization term to be added to the empirical FIM in each layer.
+            This is useful when the empirical FIM is singular or ill-conditioned.
             The regularization term is `regularization * I`, where `I` is the
-            identity matrix directly added to the Hessian matrix.
+            identity matrix directly added to the empirical FIM.
             The list is of length L, where L is the total number of
             layers.
         param_layer_map: Optional[List[int]]: Specifies how the parameters are grouped

--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -286,8 +286,8 @@ class CudaProjector(AbstractProjector):
                 too large for your GPU' error. Must be either 8, 16, or 32.
 
         Raises:
-            ValueError: When attempting to use this on a non-CUDA device
-            ImportError: When fast_jl is not installed
+            ValueError: When attempting to use this on a non-CUDA device.
+            ModuleNotFoundError: When fast_jl is not installed.
         """
         super().__init__(feature_dim, proj_dim, seed, proj_type, device)
         self.max_batch_size = max_batch_size
@@ -317,7 +317,7 @@ class CudaProjector(AbstractProjector):
         except ImportError:
             msg = "You should make sure to install the CUDA projector \
             (the fast_jl library)."
-            raise msg from ModuleNotFoundError
+            raise ModuleNotFoundError(msg) from None
 
     def project(
         self,
@@ -373,7 +373,7 @@ class CudaProjector(AbstractProjector):
                 msg = "The batch size of the CudaProjector is too large for your GPU. \
                     Reduce it by using the proj_max_batch_size argument.\
                     \nOriginal error:"
-                raise msg from RuntimeError
+                raise RuntimeError(msg) from e
             raise e from None
 
         return result

--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -1,7 +1,7 @@
 """Projection matrix constructions.
 
 This file contains functions to (1) construct random projection matrices (entries
-are normal or rademacher random variables) for dimension reduction and (2) perform
+are normal or Rademacher random variables) for dimension reduction and (2) perform
 eigen decomposition on the inverse Hessian matrix using Arnoldi iteration and derive
 the corresponding projection matrix.
 
@@ -55,24 +55,18 @@ class AbstractProjector(ABC):
         """Initializes hyperparameters for the projection.
 
         Args:
-            feature_dim (int):
-                Dimension of the features to be projected. Typically, this equal to
-                the number of parameters in the model (dimension of the gradient
-                vectors).
-            proj_dim (int):
-                Dimension after the projection.
-            seed (int):
-                Random seed for the generation of the sketching (projection)
-                matrix.
-            proj_type (Union[str, ProjectionType]):
-                The random projection (JL transform) guarantees that distances
-                will be approximately preserved for a variety of choices of the
-                random matrix (see e.g. https://arxiv.org/abs/1411.2404). Here,
+            feature_dim (int): Dimension of the features to be projected.
+                Typically, this equals the number of parameters in the model
+                (dimension of the gradient vectors).
+            proj_dim (int): Dimension after the projection.
+            seed (int): Random seed for the generation of the sketching
+                (projection) matrix.
+            proj_type (Union[str, ProjectionType]): The random projection (JL
+                transform) guarantees that distances will be approximately
+                preserved for a variety of choices of the random matrix. Here,
                 we provide an implementation for matrices with iid Gaussian
                 entries and iid Rademacher entries.
-            device (Union[str, torch.device]):
-                CUDA device to use.
-
+            device (Union[str, torch.device]): CUDA device to use.
         """
         self.feature_dim = feature_dim
         self.proj_dim = proj_dim
@@ -129,30 +123,23 @@ class BasicProjector(AbstractProjector):
         """Initializes hyperparameters for BasicProjector.
 
         Args:
-            feature_dim (int):
-                Dimension of the features to be projected. Typically, this equal to
-                the number of parameters in the model (dimension of the gradient
-                vectors).
-            proj_dim (int):
-                Dimension after the projection.
-            seed (int):
-                Random seed for the generation of the sketching (projection)
-                matrix.
-            proj_type (Union[str, ProjectionType]):
-                The random projection (JL transform) guarantees that distances
-                will be approximately preserved for a variety of choices of the
-                random matrix (see e.g. https://arxiv.org/abs/1411.2404). Here,
+            feature_dim (int): Dimension of the features to be projected.
+                Typically, this equals the number of parameters in the model
+                (dimension of the gradient vectors).
+            proj_dim (int): Dimension after the projection.
+            seed (int): Random seed for the generation of the sketching
+                (projection) matrix.
+            proj_type (Union[str, ProjectionType]): The random projection (JL
+                transform) guarantees that distances will be approximately
+                preserved for a variety of choices of the random matrix. Here,
                 we provide an implementation for matrices with iid Gaussian
                 entries and iid Rademacher entries.
-            device (Union[str, torch.device]):
-                CUDA device to use.
-            block_size (int):
-                Maximum number of projection dimension allowed. Thus,
-                min(block_size, proj_dim) will be used as the actual projection
-                dimension.
+            device (torch.device): CUDA device to use.
+            block_size (int): Maximum number of projection dimension allowed.
+                Thus, min(block_size, proj_dim) will be used as the actual
+                projection dimension.
             dtype (torch.dtype): The dtype of the projected matrix.
             ensemble_id (int): A unique ID for this ensemble.
-
         """
         super().__init__(feature_dim, proj_dim, seed, proj_type, device)
 
@@ -286,22 +273,21 @@ class CudaProjector(AbstractProjector):
 
         Args:
             feature_dim (int): Dimension of the features to be projected.
-                Typically, this equal to the number of parameters in the
-                model (dimension of the gradient vectors).
+                Typically, this equals the number of parameters in the model
+                (dimension of the gradient vectors).
             proj_dim (int): Dimension we project *to* during the projection step
             seed (int): Random seed.
             proj_type (ProjectionType): Type of randomness to use for
-                                        projection matrix (rademacher or normal).
-            device: CUDA device to use.
-            max_batch_size (int): Explicitly constraints the batch size of
+                projection matrix (rademacher or normal).
+            device (str): CUDA device to use.
+            max_batch_size (int): Explicitly constrains the batch size of
                 the CudaProjector is going to use for projection.
                 Set this if you get a 'The batch size of the CudaProjector is
                 too large for your GPU' error. Must be either 8, 16, or 32.
 
         Raises:
             ValueError: When attempting to use this on a non-CUDA device
-            msg: When fast_jl is not installed
-
+            ImportError: When fast_jl is not installed
         """
         super().__init__(feature_dim, proj_dim, seed, proj_type, device)
         self.max_batch_size = max_batch_size
@@ -346,7 +332,8 @@ class CudaProjector(AbstractProjector):
             ensemble_id (int): A unique ID for this ensemble.
 
         Raises:
-            msg: The batch size of the CudaProjector need to be reduced.
+            RuntimeError: The batch size of the CudaProjector is too large for
+                your GPU.
             RuntimeError: Too many resources requested for launch CUDA.
 
         Returns:
@@ -421,7 +408,7 @@ class ChunkedCudaProjector:
             max_chunk_size (int): The maximum size of each chunk.
             dim_per_chunk (list): The number of feature dimensions per chunk.
             feature_batch_size (int): The batch size of input feature.
-            proj_max_batch_size (int): The maximum batch size or each projector.
+            proj_max_batch_size (int): The maximum batch size for each projector.
             device (torch.device): Device to use. Will be "cuda" or "cpu".
             dtype (torch.dtype): The dtype of the projected matrix.
         """
@@ -466,8 +453,6 @@ class ChunkedCudaProjector:
             ensemble_id (int): A unique ID for this ensemble.
 
         Raises:
-            ValueError: The number of accumulated #feature dim does not match
-                dim_per_chunk.
             ValueError: The number of accumulated #feature dim does not match
                 dim_per_chunk.
 
@@ -544,7 +529,6 @@ class ChunkedCudaProjector:
                 of batch of features.
             ensemble_id (int): A unique ID for this ensemble.
 
-
         Returns:
             Tensor: The projected features.
         """
@@ -594,50 +578,45 @@ class ArnoldiProjector(AbstractProjector):
         """Initializes hyperparameters for ArnoldiProjector.
 
         Args:
-            feature_dim (int):
-                Dimension of the features to be projected. Typically, this equal to
-                the number of parameters in the model (dimension of the gradient
-                vectors).
-            proj_dim (int):
-                Dimension after the projection. This corresponds to the number of top
-                eigenvalues (top-k eigenvalues) to keep for the Hessian approximation.
-            func (Callable):
-                A Python function that takes one or more arguments. Must return a
-                single-element Tensor. The hessian will be calculated on this function.
-            x:
-                List of arguments for `func`.
-            argnums (int):
-                An integer default to 0. Specifies which argument of func to compute
-                inverse hessian with respect to.
-            max_iter (int):
-                An integer default to 100. Specifies the maximum iteration to calculate
-                the ihvp through Arnoldi Iteration.
-            norm_constant (float):
-                A float default to 1.0. Specifies a constant value for the norm of each
-                projection. In some situations (e.g. with a large numbers of parameters)
-                it might be advisable to set norm_constant > 1 to avoid dividing
-                projection components by a large normalization factor.
-            tol (float):
-                A float default to 1e-7. Specifies the break condition that decide
-                if the algorithm has converged. If the torch.norm of current basis
-                vector is less than tol, then the arnoldi_iter algorithm is truncated.
-            mode (str):
-                The auto diff mode, which can have one of the following values:
-                - rev-rev: calculate the hessian with two reverse-mode auto-diff. It has
-                        better compatibility while cost more memory.
-                - rev-fwd: calculate the hessian with the composing of reverse-mode and
-                        forward-mode. It's more memory-efficient but may not be
-                        supported by some operator.
-            regularization (float):
-                A float default to 0.0. Specifies the regularization term to be added to
-                the Hessian vector product, which is useful for the later inverse
-                calculation if the Hessian matrix is singular or ill-conditioned.
-                Specifically, the regularization term is `regularization * v`.
-            seed (int):
-                Random seed for the generation of the random initial vector to build
-                orthonormal basis for the Krylov subspaces.
-            device (Union[str, torch.device]):
-                Device to use. Default to cpu.
+            feature_dim (int): Dimension of the features to be projected.
+                Typically, this equals the number of parameters in the model
+                (dimension of the gradient vectors).
+            proj_dim (int): Dimension after the projection. This corresponds to
+                the number of top eigenvalues (top-k eigenvalues) to keep for
+                the Hessian approximation.
+            func (Callable): A Python function that takes one or more
+                arguments. Must return a single-element Tensor. The Hessian
+                will be calculated on this function.
+            x (Tuple): List of arguments for `func`.
+            argnums (int): An integer defaulting to 0. Specifies which argument
+                of func to compute inverse Hessian with respect to.
+            max_iter (int): An integer defaulting to 100. Specifies the maximum
+                iteration to calculate the ihvp through Arnoldi Iteration.
+            norm_constant (float): A float defaulting to 1.0. Specifies a
+                constant value for the norm of each projection. In some
+                situations (e.g. with a large number of parameters) it might be
+                advisable to set norm_constant > 1 to avoid dividing projection
+                components by a large normalization factor.
+            tol (float): A float defaulting to 1e-7. Specifies the break
+                condition that decides if the algorithm has converged. If the
+                torch.norm of current basis vector is less than tol, then the
+                arnoldi_iter algorithm is truncated.
+            mode (str): The auto diff mode, which can have one of the following
+                values:
+                - rev-rev: calculate the Hessian with two reverse-mode
+                  auto-diff. It has better compatibility while costing more
+                  memory.
+                - rev-fwd: calculate the Hessian with the composition of
+                  reverse-mode and forward-mode. It's more memory-efficient but
+                  may not be supported by some operators.
+            regularization (float): A float defaulting to 0.0. Specifies the
+                regularization term to be added to the Hessian vector product,
+                which is useful for the later inverse calculation if the
+                Hessian matrix is singular or ill-conditioned. Specifically,
+                the regularization term is `regularization * v`.
+            seed (int): Random seed for the generation of the random initial
+                vector to build orthonormal basis for the Krylov subspaces.
+            device (torch.device): Device to use. Defaults to cpu.
         """
         self.max_iter = max_iter
         self.norm_constant = norm_constant
@@ -674,7 +653,7 @@ class ArnoldiProjector(AbstractProjector):
         Args:
             hvp_func (Callable): A function that computes hvp.
             start_vec (Tensor): A random normalized vector for initialization.
-            n_iters (int): The number of iteration.
+            n_iters (int): The number of iterations.
             norm_constant (float): The norm normalization for each projection.
             tol (float): A tolerance value used to terminate iteration early.
             device (str): The device to run the algorithm. Defaults to "cpu".
@@ -724,11 +703,13 @@ class ArnoldiProjector(AbstractProjector):
         """Distills result of Arnoldi iteration to top_k eigenvalues and eigenvectors.
 
         Args:
-            appr_mat (Tensor): The first result from arnoldi_iter. This will be a
-                Hessenberg matrix H' approximating the Hessian H.
-            proj (Tensor): The second result from arnoldi_iter. This will be the
-                projection vectors onto the Krylov subspace K of the Hessian H.
-            top_k (int): Specfies how many eigenvalues and eigenvectors to distill.
+            appr_mat (Tensor): The first result from arnoldi_iter. This will be
+                a Hessenberg matrix H' approximating the Hessian H.
+            proj (Tensor): The second result from arnoldi_iter. This will be
+                the projection vectors onto the Krylov subspace K of the
+                Hessian H.
+            top_k (int): Specifies how many eigenvalues and eigenvectors to
+                distill.
             force_hermitian (bool): Whether to force the Hessian to Hermitian.
                 Defaults to True.
 
@@ -816,7 +797,7 @@ def make_random_projector(
             of each module equals to feature_batch_size * param_size of that module.
         feature_batch_size (int): The batch size of each tensor in the feature
             about to be projected. The typical type of feature are gradients of
-            torch.nn.Module model but can restricted to this.
+            torch.nn.Module model but can be restricted to this.
         proj_dim (int): Dimension of the projected feature.
         proj_max_batch_size (int): The maximum batch size used by fast_jl if the
             CudaProjector is used. Must be a multiple of 8. The maximum
@@ -939,53 +920,47 @@ def arnoldi_project(
     seed: int = 0,
     device: torch.device = "cpu",
 ) -> Callable:
-    """Apply Anordi algorithm to approximate iHVP.
+    """Apply Arnoldi algorithm to approximate iHVP.
 
     Args:
-        feature_dim (int):
-            Dimension of the features to be projected. Typically, this equal to
-            the number of parameters in the model (dimension of the gradient
-            vectors).
-        func (Callable):
-            A Python function that takes one or more arguments.
-            Must return a single-element Tensor. The hessian will
-            be calculated on this function. The positional arguments to func
-            must all be Tensors.
-        x: List of arguments for `func`.
-        argnums (int):
-            An integer default to 0. Specifies which argument of func
-            to compute hessian with respect to.
-        proj_dim (int):
-            Dimension after the projection. This corresponds to the number of top
-            eigenvalues (top-k eigenvalues) to keep for the Hessian approximation.
-        max_iter (int):
-            An integer default 100. Specifies the maximum iteration
-            to calculate the ihvp through Conjugate Gradient Descent.
-        norm_constant (float):
-            A float default to 1.0. Specifies a constant value
-            for the norm of each projection. In some situations (e.g. with a large
-            numbers of parameters) it might be advisable to set norm_constant > 1
-            to avoid dividing projection components by a large normalization factor.
-        tol (float):
-            A float default to 1e-7. Specifies the break condition that
-            decide if the algorithm has converged. If the torch.norm of residual
-            is less than tol, then the algorithm is truncated.
-        mode (str):
-            Defaults to "rev-fwd". The auto diff mode, which can have one of
-            the following values:
-            - rev-rev: calculate the hessian with two reverse-mode auto-diff. It has
-                       better compatibility while cost more memory.
-            - rev-fwd: calculate the hessian with the composing of reverse-mode and
-                       forward-mode. It's more memory-efficient but may not be supported
-                       by some operator.
-        regularization (float):
-            A float default to 0.0. Specifies the regularization
-            term to be added to the Hessian vector product, which is useful for the
-            later inverse calculation if the Hessian matrix is singular or
-            ill-conditioned. Specifically, the regularization term is
-            `regularization * v`.
+        feature_dim (int): Dimension of the features to be projected. Typically,
+            this equals the number of parameters in the model (dimension of the
+            gradient vectors).
+        func (Callable): A Python function that takes one or more arguments.
+            Must return a single-element Tensor. The Hessian will be calculated
+            on this function. The positional arguments to func must all be
+            Tensors.
+        x (List): List of arguments for `func`.
+        argnums (int): An integer defaulting to 0. Specifies which argument of
+            func to compute Hessian with respect to.
+        proj_dim (int): Dimension after the projection. This corresponds to the
+            number of top eigenvalues (top-k eigenvalues) to keep for the
+            Hessian approximation.
+        max_iter (int): An integer defaulting to 100. Specifies the maximum
+            iteration to calculate the ihvp through Arnoldi Iteration.
+        norm_constant (float): A float defaulting to 1.0. Specifies a constant
+            value for the norm of each projection. In some situations (e.g.
+            with a large number of parameters) it might be advisable to set
+            norm_constant > 1 to avoid dividing projection components by a
+            large normalization factor.
+        tol (float): A float defaulting to 1e-7. Specifies the break condition
+            that decides if the algorithm has converged. If the torch.norm of
+            the current basis vector is less than tol, then the algorithm is
+            truncated.
+        mode (str): The auto diff mode, which can have one of the following
+            values:
+            - rev-rev: calculate the Hessian with two reverse-mode auto-diff.
+              It has better compatibility while costing more memory.
+            - rev-fwd: calculate the Hessian with the composition of
+              reverse-mode and forward-mode. It's more memory-efficient but may
+              not be supported by some operators.
+        regularization (float): A float defaulting to 0.0. Specifies the
+            regularization term to be added to the Hessian vector product,
+            which is useful for the later inverse calculation if the Hessian
+            matrix is singular or ill-conditioned. Specifically, the
+            regularization term is `regularization * v`.
         seed (int): Random seed used by the projector. Defaults to 0.
-        device (torch.device, optional): "cuda" or "cpu".. Defaults to "cpu".
+        device (torch.device): "cuda" or "cpu". Defaults to "cpu".
 
     Returns:
         A function that applies Arnoldi algorithm on input feature.

--- a/dattri/func/utils.py
+++ b/dattri/func/utils.py
@@ -30,7 +30,7 @@ def _vectorize(
 
     Args:
         g (Dict[str, Tensor]): A dictionary containing gradient tensors to be
-        vectorized.
+            vectorized.
         batch_dim (bool, optional): Whether to include the batch dimension in the
             returned tensor. Defaults to True.
         arr (Tensor, optional): An optional pre-allocated tensor to store the
@@ -108,8 +108,8 @@ def _get_parameter_chunk_sizes(
 
     Returns:
         tuple[int, List[int]]: A tuple containing:
-        - Maximum number of parameters per chunk
-        - A list of the number of parameters in each chunk
+            - Maximum number of parameters per chunk
+            - A list of the number of parameters in each chunk
     """
     # get the number of params of each term in feature
     param_shapes = np.array(param_shape_list)
@@ -149,8 +149,8 @@ def get_parameter_chunk_sizes(
 
     Returns:
         tuple[int, List[int]]: A tuple containing:
-        - Maximum number of parameters per chunk
-        - A list of the number of parameters in each chunk
+            - Maximum number of parameters per chunk
+            - A list of the number of parameters in each chunk
     """
     # get the number of total params
     param_num = param_shape_list[0]

--- a/dattri/metrics/__init__.py
+++ b/dattri/metrics/__init__.py
@@ -1,6 +1,1 @@
 """dattri.metrics for some metric functions on data attribution."""
-
-from .brittleness import brittleness
-from .metrics import lds, loo_corr, mislabel_detection_auc
-
-__all__ = ["brittleness", "lds", "loo_corr", "mislabel_detection_auc"]

--- a/dattri/metrics/__init__.py
+++ b/dattri/metrics/__init__.py
@@ -1,1 +1,6 @@
-"""dattri.metrics for some metric function on data attribution."""
+"""dattri.metrics for some metric functions on data attribution."""
+
+from .brittleness import brittleness
+from .metrics import lds, loo_corr, mislabel_detection_auc
+
+__all__ = ["brittleness", "lds", "loo_corr", "mislabel_detection_auc"]

--- a/dattri/metrics/britteness.py
+++ b/dattri/metrics/britteness.py
@@ -1,4 +1,4 @@
-"""This module provides britteness prediction evaluate the data attribution."""
+"""This module provides brittleness prediction to evaluate the data attribution."""
 
 from __future__ import annotations
 
@@ -22,12 +22,11 @@ def brittleness(
     test_loader: DataLoader,
     scores: torch.Tensor,
     train_func: Callable[[DataLoader], torch.nn.Module],
-    eval_func: Callable[[torch.nn.Module, DataLoader],
-                        torch.Tensor],
+    eval_func: Callable[[torch.nn.Module, DataLoader], torch.Tensor],
     device: torch.device = "cpu",
     search_space: Optional[List[int]] = None,
 ) -> Optional[int]:
-    """Calculate smallest k make a test data flip.
+    """Calculate smallest k to make a test data prediction flip.
 
     This function calculate the brittleness metric by determining the smallest subset of
     training data whose removal causes the test sample's prediction to flip.
@@ -59,14 +58,16 @@ def brittleness(
         k_values,
         desc="Calculating brittleness",
         leave=False,
-        ):
+    ):
         highest_score_indices = sorted_indices[:k]
-        if check_if_flip(train_loader,
-                        test_loader,
-                        highest_score_indices,
-                        train_func,
-                        eval_func,
-                        device):
+        if check_if_flip(
+            train_loader,
+            test_loader,
+            highest_score_indices,
+            train_func,
+            eval_func,
+            device,
+        ):
             return k
     return None
 
@@ -76,8 +77,7 @@ def check_if_flip(
     test_loader: DataLoader,
     indices_to_remove: List[int],
     train_func: Callable[[DataLoader], torch.nn.Module],
-    eval_func: Callable[[torch.nn.Module, DataLoader],
-                        torch.Tensor],
+    eval_func: Callable[[torch.nn.Module, DataLoader], torch.Tensor],
     device: torch.device = "cpu",
 ) -> bool:
     """Check if a test sample flips after removing specified training data.

--- a/dattri/metrics/ground_truth.py
+++ b/dattri/metrics/ground_truth.py
@@ -19,7 +19,7 @@ import yaml
 
 
 def _dir_to_index(dir_name: str) -> int:
-    """Helper function for calculate_loo_groundtruth.
+    """Helper function for calculate_loo_ground_truth.
 
     This function returns the directory index to sort directories
     by index instead of by alphabets.
@@ -35,7 +35,7 @@ def _dir_to_index(dir_name: str) -> int:
     return int(dir_name[prefix_len:])
 
 
-def calculate_loo_groundtruth(
+def calculate_loo_ground_truth(
     target_func: Callable,
     retrain_dir: str,
     test_dataloader: torch.utils.data.DataLoader,

--- a/dattri/metrics/ground_truth.py
+++ b/dattri/metrics/ground_truth.py
@@ -19,7 +19,7 @@ import yaml
 
 
 def _dir_to_index(dir_name: str) -> int:
-    """Help function for calculate_loo_groundtruth.
+    """Helper function for calculate_loo_groundtruth.
 
     This function returns the directory index to sort directories
     by index instead of by alphabets.
@@ -40,9 +40,9 @@ def calculate_loo_groundtruth(
     retrain_dir: str,
     test_dataloader: torch.utils.data.DataLoader,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Calculate the groundtruth values for the Leave-One-Out (LOO) metric.
+    """Calculate the ground truth values for the Leave-One-Out (LOO) metric.
 
-    The LOO groundtruth is directly calculated by calculating the target value
+    The LOO ground truth is directly calculated by calculating the target value
     difference for each sample in the test dataloader on each model in the
     retrain directory. The target value is calculated by the target function.
 

--- a/dattri/metrics/ground_truth.py
+++ b/dattri/metrics/ground_truth.py
@@ -65,7 +65,7 @@ def calculate_loo_groundtruth(
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: A tuple of two tensors. First is the LOO
-            groundtruth values for each sample in test_dataloader and each model in
+            ground truth values for each sample in test_dataloader and each model in
             retrain_dir. The returned tensor has the shape
             (num_models, num_test_samples).
             Second is the tensor indicating the removed index. The returned tensor has

--- a/dattri/metrics/metrics.py
+++ b/dattri/metrics/metrics.py
@@ -1,4 +1,4 @@
-"""This module evaluate the performance of the data attribution."""
+"""This module evaluates the performance of the data attribution."""
 
 # ruff: noqa: ARG001, TCH002
 # TODO: Remove the above line after finishing the implementation of the functions.
@@ -80,22 +80,23 @@ def loo_corr(
 ) -> torch.Tensor:
     """Calculate the Leave-One-Out (LOO) correlation metric.
 
-    The LOO correlation is calculated by pearson correlation between the score
-    tensor and the groundtruth.
+    The LOO correlation is calculated by Pearson correlation between the score
+    tensor and the ground truth.
 
     TODO: more detailed description.
 
     Args:
         score (torch.Tensor): The score tensor with the shape (num_train_samples,
             num_test_samples).
-        ground_truth (torch.Tensor): A tuple of two tensors. First is the LOO
-            groundtruth values for each sample in test_dataloader and each model
-            in retrain_dir. The returned tensor has the shape (num_models,
+        ground_truth (Tuple[torch.Tensor, torch.Tensor]): A tuple of two tensors. First
+            is the LOO ground truth values for each sample in test_dataloader and each
+            model in retrain_dir. The returned tensor has the shape (num_models,
             num_test_samples). Second is the tensor indicating the removed index. The
             returned tensor has the shape (num_models,).
 
     Returns:
-        torch.Tensor: The LOO correlation metric value. The returned tensor has the
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing the LOO correlation
+            metric values and their corresponding p-values. Both tensors have the
             shape (num_test_samples,).
     """
     gt_values, _ = ground_truth
@@ -133,7 +134,7 @@ def mislabel_detection_auc(
 
     The function will calculate the false positive rates and true positive rates
     under different thresholds (number of data inspected), and return them with
-    the calculated auc (Area Under Curve).
+    the calculated AUC (Area Under Curve).
 
     Args:
         score (torch.Tensor): The self-attribution scores of shape (num_train_samples,).

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -119,7 +119,7 @@ class AttributionTask:
         self.model.eval()
 
     @staticmethod
-    def _genearte_param_layer_map(
+    def _generate_param_layer_map(
         named_parameters: Dict[str, torch.Tensor],
     ) -> List[int]:
         """This function generate the param_layer_map automatically.
@@ -328,7 +328,7 @@ class AttributionTask:
                 ), param_layer_map
             return tuple(
                 [param.flatten() for param in named_parameters.values()],
-            ), self._genearte_param_layer_map(named_parameters)
+            ), self._generate_param_layer_map(named_parameters)
         return flatten_params(named_parameters), None
 
     def get_checkpoints(self) -> List[Union[Dict[str, torch.Tensor], str]]:

--- a/docs/source/api/benchmark.rst
+++ b/docs/source/api/benchmark.rst
@@ -3,7 +3,7 @@ Benchmark Functions
 .. autofunction:: dattri.model_utils.retrain.retrain_loo
 .. autofunction:: dattri.model_utils.retrain.retrain_lds
 
-.. autofunction:: dattri.metrics.ground_truth.calculate_loo_groundtruth
+.. autofunction:: dattri.metrics.ground_truth.calculate_loo_ground_truth
 .. autofunction:: dattri.metrics.ground_truth.calculate_lds_ground_truth
 .. autofunction:: dattri.benchmark.utils.flip_label
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

This PR mainly improves the docstring of files under dattri.func and dattri.metrics.

### 1. Motivation and Context

<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

There are some format inconsistency issues and typos in the docstrings. 

### 2. Summary of the change

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

- Improved docstring by making the format more consistent and fixing some typos
- For `dattri/func/utils.py`, changed all `torch.Tensor` to `Tensor` since it is imported
- Fixed a typo in `dattri/task.py`: `_genearte_param_layer_map` -> `_generate_param_layer_map`
- Changed `calculate_loo_groundtruth` in `dattri/metrics/ground_truth.py` to `calculate_loo_ground_truth`. Also changed all the references to this function.

### 3. What tests have been added/updated for the change?
-  N/A: No test will be added. Mainly changed docstring and `torch.Tensor` to `Tensor`. The only code change is a membership function name in `task.py` and a util function in `ground_truth.py`, which should be fine.