### PR TITLE
[DO NOT MERGE] Reference refactoring of BaseInnerProductAttributor

### DIFF
--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -41,7 +41,7 @@ class BaseAttributor(ABC):
 
         Args:
             full_train_dataloader (torch.utils.data.DataLoader): The dataloader for
-                the training data.
+                the full training data.
 
         Returns:
             None.
@@ -83,7 +83,7 @@ class BaseInnerProductAttributor(BaseAttributor):
             transformation_kwargs (Optional[Dict[str, Any]]): The keyword arguments for
                 the transformation function. More specifically, it will be stored in
                 the `transformation_kwargs` attribute and be used by some customized
-                member functions, e.g., `transformation_on_query`, where the
+                member functions, e.g., `transform_test_rep`, where the
                 transformation such as hessian matrix or Fisher Information matrix is
                 calculated.
             device (str): The device to run the attributor.
@@ -91,7 +91,6 @@ class BaseInnerProductAttributor(BaseAttributor):
         self.task = task
         self.transformation_kwargs = transformation_kwargs or {}
         self.device = device
-        self.index = 0
 
     def _set_test_data(self, dataloader: torch.utils.data.DataLoader) -> None:
         """Set test dataloader.
@@ -99,7 +98,7 @@ class BaseInnerProductAttributor(BaseAttributor):
         Args:
             dataloader (DataLoader): The dataloader for test samples to be attributed.
         """
-        # This function may be overrided by the subclass
+        # This function may be overridden by the subclass
         self.test_dataloader = dataloader
 
     def _set_train_data(self, dataloader: torch.utils.data.DataLoader) -> None:
@@ -108,7 +107,7 @@ class BaseInnerProductAttributor(BaseAttributor):
         Args:
             dataloader (DataLoader): The dataloader for train samples to be attributed.
         """
-        # This function may be overrided by the subclass
+        # This function may be overridden by the subclass
         self.train_dataloader = dataloader
 
     def _set_full_train_data(self, dataloader: torch.utils.data.DataLoader) -> None:
@@ -117,104 +116,127 @@ class BaseInnerProductAttributor(BaseAttributor):
         Args:
             dataloader (DataLoader): The dataloader for full training samples.
         """
-        # This function may be overrided by the subclass
+        # This function may be overridden by the subclass
         self.full_train_dataloader = dataloader
 
-    def generate_test_query(
+    def generate_test_rep(
         self,
-        index: int,
+        ckpt_idx: int,
         data: Tuple[torch.Tensor, ...],
     ) -> torch.Tensor:
-        """Calculating the query based on the test data.
+        """Getting the initial representations of the test data.
 
-        Inner product attributor calculates the inner product between the
-        train query and the transformation of the test query. This function
-        calculates the test query based on the test data.
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function generates the
+        initial test representations.
 
         Args:
-            index (int): The index of the model parameters. This index
-                is used for ensembling of different trained model
-                parameters.
-            data (Tuple[Tensor]): The test data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            data (Tuple[Tensor]): The test data. Typically, this is a tuple
+                of input data and target data but the number of items in this
+                tuple should align with the corresponding argument in the
+                target function. The tensors' shape follows (1, batch_size, ...).
 
         Returns:
-            torch.Tensor: The query based on the test data. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
+            torch.Tensor: The initial representations of the test data. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
         """
-        model_params, _ = self.task.get_param(index)
+        model_params, _ = self.task.get_param(ckpt_idx)
         return self.task.get_grad_target_func()(model_params, data)
 
-    def generate_train_query(
+    def generate_train_rep(
         self,
-        index: int,
+        ckpt_idx: int,
         data: Tuple[torch.Tensor, ...],
     ) -> torch.Tensor:
-        """Calculating the query based on the train data.
+        """Generate the initial representations of the train data.
 
-        Inner product attributor calculates the inner product between the
-        train query and the transformation of the test query. This function
-        calculates the train query based on the train data.
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function generates the
+        initial train representations.
 
         Args:
-            index (int): The index of the model parameters. This index
-                is used for ensembling of different trained model
-                parameters.
-            data (Tuple[Tensor]): The train data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            data (Tuple[Tensor]): The train data. Typically, this is a tuple
+                of input data and target data but the number of items in this
+                tuple should align with the corresponding argument in the
+                target function. The tensors' shape follows (1, batch_size, ...).
 
         Returns:
-            torch.Tensor: The query based on the train data. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
+            torch.Tensor: The initial representations of the train data. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
         """
-        model_params, _ = self.task.get_param(index)
+        model_params, _ = self.task.get_param(ckpt_idx)
         return self.task.get_grad_loss_func()(model_params, data)
 
     @abstractmethod
-    def transformation_on_query(
+    def transform_test_rep(
         self,
-        index: int,
-        train_data: Tuple[torch.Tensor, ...],
-        query: torch.Tensor,
+        ckpt_idx: int,
+        test_rep: torch.Tensor,
     ) -> torch.Tensor:
-        """Calculate the transformation on the query.
+        """Transform the test representations.
 
-        Inner product attributor calculates the inner product between the
-        train query and the transformation of the test query. This function
-        calculates the transformation of the test query.
-
-        Normally speaking, this function may return any transformation on the query.
-        Hessian Matrix and Fisher Information Matrix are two common transformations.
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function calculates the
+        transformation of the test representations. For example, the transformation
+        could be the product of the test representations and the inverse Hessian matrix.
 
         Args:
-            index (int): The index of the model parameters. This index
-                is used for ensembling of different trained model.
-            train_data (Tuple[Tensor]): Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
-            query (torch.Tensor): The query to be transformed. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            test_rep (torch.Tensor): The test representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
 
         Returns:
-            torch.Tensor: The transformation on the query. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, transformed_dimension).
+            torch.Tensor: The transformed test representations. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, transformed_dimension).
         """
 
-    def cache(self, full_train_dataloader: DataLoader) -> None:
-        """Cache the dataset for inverse hessian calculation.
+    @abstractmethod
+    def transform_train_rep(
+        self,
+        ckpt_idx: int,
+        train_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Transform the train representations.
+
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function calculates the
+        transformation of the train representations. For example, the transformation
+        could be a dimension reduction of the train representations.
 
         Args:
-            full_train_dataloader (DataLoader): The dataloader
-                with full training samples for inverse hessian calculation.
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            train_rep (torch.Tensor): The train representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
+
+        Returns:
+            torch.Tensor: The transformed train representations. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, transformed_dimension).
+        """
+
+    def cache(self, full_train_dataloader: torch.utils.data.DataLoader) -> None:
+        """Cache the full training dataloader.
+
+        By default, the cache function only caches the full training dataloader.
+        Subclasses may override this function to precompute and cache more information.
+
+        Args:
+            full_train_dataloader (torch.utils.data.DataLoader): The dataloader for
+                the full training data.
+
+        Returns:
+            None.
         """
         self._set_full_train_data(full_train_dataloader)
 
@@ -260,12 +282,8 @@ class BaseInnerProductAttributor(BaseAttributor):
 
         # TODO: sometimes the train dataloader could be swapped with the test dataloader
         # prepare a checkpoint-specific seed
-        checkpoint_running_count = 0
         for checkpoint_idx in range(len(self.task.get_checkpoints())):
-            # set index to current one
-            self.index = checkpoint_idx
-            checkpoint_running_count += 1
-            tda_output *= checkpoint_running_count - 1
+            tda_output *= checkpoint_idx
             for train_batch_idx, train_batch_data_ in enumerate(
                 tqdm(
                     train_dataloader,
@@ -273,14 +291,19 @@ class BaseInnerProductAttributor(BaseAttributor):
                     leave=False,
                 ),
             ):
-                # get gradient of train
+                # move to device
                 train_batch_data = tuple(
                     data.to(self.device).unsqueeze(0) for data in train_batch_data_
                 )
-
-                train_batch_grad = self.generate_train_query(
-                    index=self.index,
+                # get initial representations of train data
+                train_batch_rep = self.generate_train_rep(
+                    ckpt_idx=checkpoint_idx,
                     data=train_batch_data,
+                )
+                # transform the train representations
+                train_batch_rep = self.transform_train_rep(
+                    ckpt_idx=checkpoint_idx,
+                    train_rep=train_batch_rep,
                 )
 
                 for test_batch_idx, test_batch_data_ in enumerate(
@@ -290,26 +313,20 @@ class BaseInnerProductAttributor(BaseAttributor):
                         leave=False,
                     ),
                 ):
-                    # get gradient of test
+                    # move to device
                     test_batch_data = tuple(
                         data.to(self.device).unsqueeze(0) for data in test_batch_data_
                     )
-
-                    test_batch_grad = self.generate_test_query(
-                        index=self.index,
+                    # get initial representations of test data
+                    test_batch_rep = self.generate_test_rep(
+                        ckpt_idx=checkpoint_idx,
                         data=test_batch_data,
                     )
-
-                    vector_product = 0
-                    for full_data_ in self.full_train_dataloader:
-                        # move to device
-                        full_data = tuple(data.to(self.device) for data in full_data_)
-                        vector_product += self.transformation_on_query(
-                            index=self.index,
-                            train_data=full_data,
-                            query=test_batch_grad,
-                            **self.transformation_kwargs,
-                        )
+                    # transform the test representations
+                    test_batch_rep = self.transform_test_rep(
+                        ckpt_idx=checkpoint_idx,
+                        test_rep=test_batch_rep,
+                    )
 
                     # results position based on batch info
                     row_st = train_batch_idx * train_dataloader.batch_size
@@ -325,9 +342,9 @@ class BaseInnerProductAttributor(BaseAttributor):
                     )
 
                     tda_output[row_st:row_ed, col_st:col_ed] += (
-                        train_batch_grad @ vector_product.T
+                        train_batch_rep @ test_batch_rep.T
                     )
 
-        tda_output /= checkpoint_running_count
+            tda_output /= checkpoint_idx + 1
 
         return tda_output

--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional, Tuple
+    from typing import Optional, Tuple
 
     import torch
     from torch.utils.data import DataLoader
@@ -73,23 +73,15 @@ class BaseInnerProductAttributor(BaseAttributor):
         self,
         task: AttributionTask,
         device: Optional[str] = "cpu",
-        **transformation_kwargs: Dict[str, Any],
     ) -> None:
         """Initialize the attributor.
 
         Args:
             task (AttributionTask): The task to be attributed. The task should
                 be an instance of `AttributionTask`.
-            transformation_kwargs (Optional[Dict[str, Any]]): The keyword arguments for
-                the transformation function. More specifically, it will be stored in
-                the `transformation_kwargs` attribute and be used by some customized
-                member functions, e.g., `transform_test_rep`, where the
-                transformation such as hessian matrix or Fisher Information matrix is
-                calculated.
             device (str): The device to run the attributor.
         """
         self.task = task
-        self.transformation_kwargs = transformation_kwargs or {}
         self.device = device
 
     def _set_test_data(self, dataloader: torch.utils.data.DataLoader) -> None:


### PR DESCRIPTION
## Description

This PR is a reference implementation to refactor the BaseInnerProductAttributor, which is NOT intended to be merged (and has not been tested). As an example, the Arnoldi attributor is re-implemented to demonstrate how the new API of BaseInnerProductAttributor can be used.

A few major changes in BaseInnerProductAttributor:
- transformation could now be applied to both train data representations/gradients and test data representations/gradients
- the batching over the full training data for transformation was original dealt inside `.attribute()` with a simple average, which lacks enough flexibility; it is now moved into the transform functions
- `.cache()` could do more than just storing the full training dataloader. For example, the Arnoldi projector is now processed and cached in transformation_on_query in a hacky way. In this PR, this is moved to .cache()
- removed transformation_kwargs and added an __init__ for the subclass. It's better to specify these attributor hyperparameters explicitly than relying on a kwargs


