### PR TITLE
[dattri.metrics] change the shape of score in `lds` to improve consistency

### DIFF
--- a/dattri/metrics/metrics.py
+++ b/dattri/metrics/metrics.py
@@ -39,7 +39,7 @@ def lds(
             ground truth values for each test sample. The second tensor contains the
             p-values of the correlation. Both have the shape (num_test_samples,).
     """
-    score = score.T
+    score = score.T.cpu()
     gt_values, indices = ground_truth
     num_subsets = indices.shape[0]
     num_test_samples = score.shape[0]
@@ -100,6 +100,7 @@ def loo_corr(
             metric values and their corresponding p-values. Both tensors have the
             shape (num_test_samples,).
     """
+    score = score.cpu()
     gt_values, _ = ground_truth
     num_test_samples = score.shape[1]
 

--- a/dattri/metrics/metrics.py
+++ b/dattri/metrics/metrics.py
@@ -25,7 +25,7 @@ def lds(
 
     Args:
         score (torch.Tensor): The data attribution score tensor with the shape
-            (num_test_samples, num_train_samples).
+            (num_train_samples, num_test_samples).
         ground_truth (Tuple[torch.Tensor, torch.Tensor]): A tuple of two tensors. The
             first one has the shape (num_subsets, num_test_samples), which is the
             ground-truth target values for all test samples under `num_subsets` models,
@@ -39,6 +39,7 @@ def lds(
             ground truth values for each test sample. The second tensor contains the
             p-values of the correlation. Both have the shape (num_test_samples,).
     """
+    score = score.T
     gt_values, indices = ground_truth
     num_subsets = indices.shape[0]
     num_test_samples = score.shape[0]

--- a/example/mnist_lr/influence_function_lds.py
+++ b/example/mnist_lr/influence_function_lds.py
@@ -37,5 +37,5 @@ with torch.no_grad():
                 sampler=model_details["test_sampler"])
     )
 
-lds_score = lds(score.cpu().T, groundtruth)[0]
+lds_score = lds(-score.cpu(), groundtruth)[0]
 print("lds:", torch.mean(lds_score[~torch.isnan(lds_score)]))

--- a/test/dattri/metrics/test_lds.py
+++ b/test/dattri/metrics/test_lds.py
@@ -27,7 +27,7 @@ class TestLDSFunction(unittest.TestCase):
         indices = torch.tensor([[0, 1], [0, 2], [1, 2]])
         ground_truth = (gt_values, indices)
 
-        lds_corr, lds_pval = lds(score, ground_truth)
+        lds_corr, lds_pval = lds(score.T, ground_truth)
 
         expected_corr = torch.tensor([1.0, 0.8660254037844387], dtype=torch.float32)
         expected_pval = torch.tensor([0.0, 0.3333333333333332], dtype=torch.float32)


### PR DESCRIPTION
## Description

### 1. Motivation and Context
Currently, we have all the attributor and `loo_corr` accept score in shape of (num_train_samples, num_test_samples). It would be strange if we have `lds` accept (num_test_samples, num_train_samples). 

### 2. Summary of the change
1. Change the shape of `score` in `dattri.metrics.metrics.lds` to be (num_train_samples, num_test_samples).
2. Add a cpu transformation since the calculation will happen in cpu for the correlation calculation, this avoid some possible error in users' code if they do not change the device explicitly.

### 3. What tests have been added/updated for the change?
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
