### PR TITLE
[dattri.algorithm] Reference refactoring of BaseInnerProductAttributor

### DIFF
--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional, Tuple
+    from typing import Optional, Tuple
 
     import torch
     from torch.utils.data import DataLoader
@@ -41,7 +41,7 @@ class BaseAttributor(ABC):
 
         Args:
             full_train_dataloader (torch.utils.data.DataLoader): The dataloader for
-                the training data.
+                the full training data.
 
         Returns:
             None.
@@ -73,25 +73,16 @@ class BaseInnerProductAttributor(BaseAttributor):
         self,
         task: AttributionTask,
         device: Optional[str] = "cpu",
-        **transformation_kwargs: Dict[str, Any],
     ) -> None:
         """Initialize the attributor.
 
         Args:
             task (AttributionTask): The task to be attributed. The task should
                 be an instance of `AttributionTask`.
-            transformation_kwargs (Optional[Dict[str, Any]]): The keyword arguments for
-                the transformation function. More specifically, it will be stored in
-                the `transformation_kwargs` attribute and be used by some customized
-                member functions, e.g., `transformation_on_query`, where the
-                transformation such as hessian matrix or Fisher Information matrix is
-                calculated.
             device (str): The device to run the attributor.
         """
         self.task = task
-        self.transformation_kwargs = transformation_kwargs or {}
         self.device = device
-        self.index = 0
 
     def _set_test_data(self, dataloader: torch.utils.data.DataLoader) -> None:
         """Set test dataloader.
@@ -99,7 +90,7 @@ class BaseInnerProductAttributor(BaseAttributor):
         Args:
             dataloader (DataLoader): The dataloader for test samples to be attributed.
         """
-        # This function may be overrided by the subclass
+        # This function may be overridden by the subclass
         self.test_dataloader = dataloader
 
     def _set_train_data(self, dataloader: torch.utils.data.DataLoader) -> None:
@@ -108,7 +99,7 @@ class BaseInnerProductAttributor(BaseAttributor):
         Args:
             dataloader (DataLoader): The dataloader for train samples to be attributed.
         """
-        # This function may be overrided by the subclass
+        # This function may be overridden by the subclass
         self.train_dataloader = dataloader
 
     def _set_full_train_data(self, dataloader: torch.utils.data.DataLoader) -> None:
@@ -117,104 +108,138 @@ class BaseInnerProductAttributor(BaseAttributor):
         Args:
             dataloader (DataLoader): The dataloader for full training samples.
         """
-        # This function may be overrided by the subclass
+        # This function may be overridden by the subclass
         self.full_train_dataloader = dataloader
 
-    def generate_test_query(
+    def generate_test_rep(
         self,
-        index: int,
+        ckpt_idx: int,
         data: Tuple[torch.Tensor, ...],
     ) -> torch.Tensor:
-        """Calculating the query based on the test data.
+        """Getting the initial representations of the test data.
 
-        Inner product attributor calculates the inner product between the
-        train query and the transformation of the test query. This function
-        calculates the test query based on the test data.
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function generates the
+        initial test representations.
+
+        The default implementation calculates the gradient of the test loss with respect
+        to the parameter. Subclasses may override this function to calculate something
+        else.
 
         Args:
-            index (int): The index of the model parameters. This index
-                is used for ensembling of different trained model
-                parameters.
-            data (Tuple[Tensor]): The test data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            data (Tuple[Tensor]): The test data. Typically, this is a tuple
+                of input data and target data but the number of items in this
+                tuple should align with the corresponding argument in the
+                target function. The tensors' shape follows (1, batch_size, ...).
 
         Returns:
-            torch.Tensor: The query based on the test data. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
+            torch.Tensor: The initial representations of the test data. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
         """
-        model_params, _ = self.task.get_param(index)
+        model_params, _ = self.task.get_param(ckpt_idx)
         return self.task.get_grad_target_func()(model_params, data)
 
-    def generate_train_query(
+    def generate_train_rep(
         self,
-        index: int,
+        ckpt_idx: int,
         data: Tuple[torch.Tensor, ...],
     ) -> torch.Tensor:
-        """Calculating the query based on the train data.
+        """Generate the initial representations of the train data.
 
-        Inner product attributor calculates the inner product between the
-        train query and the transformation of the test query. This function
-        calculates the train query based on the train data.
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function generates the
+        initial train representations.
+
+        The default implementation calculates the gradient of the train loss with
+        respect to the parameter. Subclasses may override this function to
+        calculate something else.
 
         Args:
-            index (int): The index of the model parameters. This index
-                is used for ensembling of different trained model
-                parameters.
-            data (Tuple[Tensor]): The train data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            data (Tuple[Tensor]): The train data. Typically, this is a tuple
+                of input data and target data but the number of items in this
+                tuple should align with the corresponding argument in the
+                target function. The tensors' shape follows (1, batch_size, ...).
 
         Returns:
-            torch.Tensor: The query based on the train data. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
+            torch.Tensor: The initial representations of the train data. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
         """
-        model_params, _ = self.task.get_param(index)
+        model_params, _ = self.task.get_param(ckpt_idx)
         return self.task.get_grad_loss_func()(model_params, data)
 
-    @abstractmethod
-    def transformation_on_query(
+    def transform_test_rep(  # noqa: PLR6301
         self,
-        index: int,
-        train_data: Tuple[torch.Tensor, ...],
-        query: torch.Tensor,
+        ckpt_idx: int,  # noqa:ARG002
+        test_rep: torch.Tensor,
     ) -> torch.Tensor:
-        """Calculate the transformation on the query.
+        """Transform the test representations.
 
-        Inner product attributor calculates the inner product between the
-        train query and the transformation of the test query. This function
-        calculates the transformation of the test query.
-
-        Normally speaking, this function may return any transformation on the query.
-        Hessian Matrix and Fisher Information Matrix are two common transformations.
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function calculates the
+        transformation of the test representations. For example, the transformation
+        could be the product of the test representations and the inverse Hessian matrix.
 
         Args:
-            index (int): The index of the model parameters. This index
-                is used for ensembling of different trained model.
-            train_data (Tuple[Tensor]): Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
-            query (torch.Tensor): The query to be transformed. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            test_rep (torch.Tensor): The test representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
 
         Returns:
-            torch.Tensor: The transformation on the query. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, transformed_dimension).
+            torch.Tensor: The transformed test representations. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, transformed_dimension).
         """
+        return test_rep
 
-    def cache(self, full_train_dataloader: DataLoader) -> None:
-        """Cache the dataset for inverse hessian calculation.
+    def transform_train_rep(  # noqa: PLR6301
+        self,
+        ckpt_idx: int,  # noqa:ARG002
+        train_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Transform the train representations.
+
+        Inner product attributor calculates the inner product between the (transformed)
+        train representations and test representations. This function calculates the
+        transformation of the train representations. For example, the transformation
+        could be a dimension reduction of the train representations.
 
         Args:
-            full_train_dataloader (DataLoader): The dataloader
-                with full training samples for inverse hessian calculation.
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            train_rep (torch.Tensor): The train representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
+
+        Returns:
+            torch.Tensor: The transformed train representations. Typically,
+                it is a 2-d dimensional tensor with the shape of
+                (batch_size, transformed_dimension).
+        """
+        return train_rep
+
+    def cache(self, full_train_dataloader: torch.utils.data.DataLoader) -> None:
+        """Cache the full training dataloader.
+
+        By default, the cache function only caches the full training dataloader.
+        Subclasses may override this function to precompute and cache more information.
+
+        Args:
+            full_train_dataloader (torch.utils.data.DataLoader): The dataloader for
+                the full training data. Ideally, the batch size of the dataloader
+                should be the same as the number of training samples to get the
+                best accuracy for some attributors. Smaller batch size may lead to
+                a less accurate result but lower memory consumption.
+
+        Returns:
+            None.
         """
         self._set_full_train_data(full_train_dataloader)
 
@@ -260,12 +285,8 @@ class BaseInnerProductAttributor(BaseAttributor):
 
         # TODO: sometimes the train dataloader could be swapped with the test dataloader
         # prepare a checkpoint-specific seed
-        checkpoint_running_count = 0
         for checkpoint_idx in range(len(self.task.get_checkpoints())):
-            # set index to current one
-            self.index = checkpoint_idx
-            checkpoint_running_count += 1
-            tda_output *= checkpoint_running_count - 1
+            tda_output *= checkpoint_idx
             for train_batch_idx, train_batch_data_ in enumerate(
                 tqdm(
                     train_dataloader,
@@ -273,14 +294,19 @@ class BaseInnerProductAttributor(BaseAttributor):
                     leave=False,
                 ),
             ):
-                # get gradient of train
+                # move to device
                 train_batch_data = tuple(
                     data.to(self.device).unsqueeze(0) for data in train_batch_data_
                 )
-
-                train_batch_grad = self.generate_train_query(
-                    index=self.index,
+                # get initial representations of train data
+                train_batch_rep = self.generate_train_rep(
+                    ckpt_idx=checkpoint_idx,
                     data=train_batch_data,
+                )
+                # transform the train representations
+                train_batch_rep = self.transform_train_rep(
+                    ckpt_idx=checkpoint_idx,
+                    train_rep=train_batch_rep,
                 )
 
                 for test_batch_idx, test_batch_data_ in enumerate(
@@ -290,26 +316,20 @@ class BaseInnerProductAttributor(BaseAttributor):
                         leave=False,
                     ),
                 ):
-                    # get gradient of test
+                    # move to device
                     test_batch_data = tuple(
                         data.to(self.device).unsqueeze(0) for data in test_batch_data_
                     )
-
-                    test_batch_grad = self.generate_test_query(
-                        index=self.index,
+                    # get initial representations of test data
+                    test_batch_rep = self.generate_test_rep(
+                        ckpt_idx=checkpoint_idx,
                         data=test_batch_data,
                     )
-
-                    vector_product = 0
-                    for full_data_ in self.full_train_dataloader:
-                        # move to device
-                        full_data = tuple(data.to(self.device) for data in full_data_)
-                        vector_product += self.transformation_on_query(
-                            index=self.index,
-                            train_data=full_data,
-                            query=test_batch_grad,
-                            **self.transformation_kwargs,
-                        )
+                    # transform the test representations
+                    test_batch_rep = self.transform_test_rep(
+                        ckpt_idx=checkpoint_idx,
+                        test_rep=test_batch_rep,
+                    )
 
                     # results position based on batch info
                     row_st = train_batch_idx * train_dataloader.batch_size
@@ -325,9 +345,9 @@ class BaseInnerProductAttributor(BaseAttributor):
                     )
 
                     tda_output[row_st:row_ed, col_st:col_ed] += (
-                        train_batch_grad @ vector_product.T
+                        train_batch_rep @ test_batch_rep.T
                     )
 
-        tda_output /= checkpoint_running_count
+            tda_output /= checkpoint_idx + 1
 
         return tda_output

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     from torch import Tensor
     from torch.utils.data import DataLoader
 
+    from dattri.task import AttributionTask
+
 import warnings
 from functools import partial
 
@@ -222,27 +224,42 @@ class IFAttributor(BaseAttributor):
 class IFAttributorExplicit(BaseInnerProductAttributor):
     """The inner product attributor with explicit inverse hessian transformation."""
 
-    def transformation_on_query(
+    def __init__(
         self,
-        index: int,
-        train_data: Tuple[torch.Tensor, ...],
-        query: torch.Tensor,
-        **transformation_kwargs,
-    ) -> torch.Tensor:
-        """Calculate the transformation on the query through ihvp_explicit.
+        task: AttributionTask,
+        device: Optional[str] = "cpu",
+        regularization: float = 0.0,
+    ) -> None:
+        """Initialize the explicit inverse hessian attributor.
 
         Args:
-            index (int): The index of the model parameters. This index
+            task (AttributionTask): The task to be attributed. The task should
+                be an instance of `AttributionTask`.
+            device (str): The device to run the attributor. Default is cpu.
+            regularization (float): A float default to 0.0. Specifies the regularization
+                term to be added to the Hessian matrix. This is useful when the Hessian
+                matrix is singular or ill-conditioned. The regularization term is
+                `regularization * I`, where `I` is the identity matrix directly added
+                to the Hessian matrix.
+        """
+        super().__init__(task, device)
+        self.transformation_kwargs = {
+            "regularization": regularization,
+        }
+
+    def transform_test_rep(
+        self,
+        ckpt_idx: int,
+        test_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Calculate the transformation on the test rep through ihvp_explicit.
+
+        Args:
+            ckpt_idx (int): The index of the model parameters. This index
                 is used for ensembling of different trained model.
-            train_data (Tuple[Tensor]): The train data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
-            query (torch.Tensor): The query to be transformed. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
-            transformation_kwargs (Dict[str, Any]): The keyword arguments for
-                the transformation function.
+            test_rep (torch.Tensor): The test representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
 
         Returns:
             torch.Tensor: The transformation on the query. Normally it is a 2-d
@@ -250,38 +267,75 @@ class IFAttributorExplicit(BaseInnerProductAttributor):
         """
         from dattri.func.hessian import ihvp_explicit
 
-        self.ihvp_func = ihvp_explicit(
-            partial(self.task.get_loss_func(), data_target_pair=train_data),
-            **transformation_kwargs,
-        )
-        model_params, _ = self.task.get_param(index)
-        return self.ihvp_func((model_params,), query).detach()
+        vector_product = 0
+        model_params, _ = self.task.get_param(ckpt_idx)
+        for full_data_ in self.full_train_dataloader:
+            # move to device
+            full_data = tuple(data.to(self.device) for data in full_data_)
+            self.ihvp_func = ihvp_explicit(
+                partial(self.task.get_loss_func(), data_target_pair=full_data),
+                **self.transformation_kwargs,
+            )
+            vector_product += self.ihvp_func((model_params,), test_rep).detach()
+        return vector_product
 
 
 class IFAttributorCG(BaseInnerProductAttributor):
     """The inner product attributor with CG inverse hessian transformation."""
 
-    def transformation_on_query(
+    def __init__(
         self,
-        index: int,
-        train_data: Tuple[torch.Tensor, ...],
-        query: torch.Tensor,
-        **transformation_kwargs,
-    ) -> torch.Tensor:
-        """Calculate the transformation on the query through ihvp_cg.
+        task: AttributionTask,
+        device: Optional[str] = "cpu",
+        max_iter: int = 10,
+        tol: float = 1e-7,
+        mode: str = "rev-rev",
+        regularization: float = 0.0,
+    ) -> None:
+        """Initialize the CG inverse hessian attributor.
 
         Args:
-            index (int): The index of the model parameters. This index
+            task (AttributionTask): The task to be attributed. The task should
+                be an instance of `AttributionTask`.
+            device (str): The device to run the attributor. Default is cpu.
+            max_iter (int): An integer default 10. Specifies the maximum iteration
+                to calculate the ihvp through Conjugate Gradient Descent.
+            tol (float): A float default to 1e-7. Specifies the break condition that
+                decide if the algorithm has converged. If the torch.norm of residual
+                is less than tol, then the algorithm is truncated.
+            mode (str): The auto diff mode, which can have one of the following values:
+                - rev-rev: calculate the hessian with two reverse-mode auto-diff. It has
+                        better compatibility while cost more memory.
+                - rev-fwd: calculate the hessian with the composing of reverse-mode and
+                        forward-mode. It's more memory-efficient but may not be
+                        supported by some operator.
+            regularization (float): A float default to 0.0. Specifies the regularization
+                term to be added to the Hessian vector product, which is useful for the
+                later inverse calculation if the Hessian matrix is singular or
+                ill-conditioned. Specifically, the regularization term is
+                `regularization * v`.
+        """
+        super().__init__(task, device)
+        self.transformation_kwargs = {
+            "max_iter": max_iter,
+            "tol": tol,
+            "mode": mode,
+            "regularization": regularization,
+        }
+
+    def transform_test_rep(
+        self,
+        ckpt_idx: int,
+        test_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Calculate the transformation on the test rep through ihvp_cg.
+
+        Args:
+            ckpt_idx (int): The index of the model parameters. This index
                 is used for ensembling of different trained model.
-            train_data (Tuple[Tensor]): The train data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
-            query (torch.Tensor): The query to be transformed. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
-            transformation_kwargs (Dict[str, Any]): The keyword arguments for
-                the transformation function.
+            test_rep (torch.Tensor): The test representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
 
         Returns:
             torch.Tensor: The transformation on the query. Normally it is a 2-d
@@ -289,84 +343,205 @@ class IFAttributorCG(BaseInnerProductAttributor):
         """
         from dattri.func.hessian import ihvp_cg
 
-        self.ihvp_func = ihvp_cg(
-            partial(self.task.get_loss_func(), data_target_pair=train_data),
-            **transformation_kwargs,
-        )
-        model_params, _ = self.task.get_param(index)
-        return self.ihvp_func((model_params,), query).detach()
+        vector_product = 0
+        model_params, _ = self.task.get_param(ckpt_idx)
+        for full_data_ in self.full_train_dataloader:
+            # move to device
+            full_data = tuple(data.to(self.device) for data in full_data_)
+            self.ihvp_func = ihvp_cg(
+                partial(self.task.get_loss_func(), data_target_pair=full_data),
+                **self.transformation_kwargs,
+            )
+            vector_product += self.ihvp_func((model_params,), test_rep).detach()
+        return vector_product
 
 
 class IFAttributorArnoldi(BaseInnerProductAttributor):
-    """The inner product attributor with Arnoldi inverse hessian transformation."""
+    """The inner product attributor with Arnoldi projection transformation."""
 
-    def transformation_on_query(
+    def __init__(
         self,
-        index: int,
-        train_data: Tuple[torch.Tensor, ...],
-        query: torch.Tensor,
-        **transformation_kwargs,
-    ) -> torch.Tensor:
-        """Calculate the transformation on the query through ihvp_arnoldi.
+        task: AttributionTask,
+        device: Optional[str] = "cpu",
+        proj_dim: int = 100,
+        max_iter: int = 100,
+        norm_constant: float = 1.0,
+        tol: float = 1e-7,
+        regularization: float = 0.0,
+        seed: int = 0,
+    ) -> None:
+        """Initialize the Arnoldi projection attributor.
 
         Args:
-            index (int): The index of the model parameters. This index
-                is used for ensembling of different trained model.
-            train_data (Tuple[Tensor]): The train data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
-            query (torch.Tensor): The query to be transformed. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
-            transformation_kwargs (Dict[str, Any]): The keyword arguments for
-                the transformation function.
-
-        Returns:
-            torch.Tensor: The transformation on the query. Normally it is a 2-d
-                dimensional tensor with the shape of (batchsize, transformed_dimension).
+            task (AttributionTask): The task to be attributed. The task should
+                be an instance of `AttributionTask`.
+            device (str): The device to run the attributor. Default is cpu.
+            proj_dim (int): Dimension after the projection. This corresponds to the
+                number of top eigenvalues (top-k eigenvalues) to keep for the
+                Hessian approximation.
+            max_iter (int): An integer defaulting to 100. Specifies the maximum
+                iteration to calculate the ihvp through Arnoldi Iteration.
+            norm_constant (float): A float defaulting to 1.0. Specifies a constant
+                value for the norm of each projection. In some situations (e.g.
+                with a large number of parameters) it might be advisable to set
+                norm_constant > 1 to avoid dividing projection components by a
+                large normalization factor.
+            tol (float): A float defaulting to 1e-7. Specifies the break condition
+                that decides if the algorithm has converged. If the torch.norm of
+                the current basis vector is less than tol, then the algorithm is
+                truncated.
+            regularization (float): A float defaulting to 0.0. Specifies the
+                regularization term to be added to the Hessian vector product,
+                which is useful for the later inverse calculation if the Hessian
+                matrix is singular or ill-conditioned. Specifically, the
+                regularization term is `regularization * v`.
+            seed (int): Random seed used by the projector. Defaults to 0.
         """
+        super().__init__(task, device)
+        self.proj_dim = proj_dim
+        self.max_iter = max_iter
+        self.norm_constant = norm_constant
+        self.tol = tol
+        self.regularization = regularization
+        self.seed = seed
+
+    def cache(
+        self,
+        full_train_dataloader: DataLoader,
+    ) -> None:
+        """Cache the dataset and pre-calculate the Arnoldi projector.
+
+        Args:
+            full_train_dataloader (DataLoader): The dataloader with full training data.
+        """
+        self.full_train_dataloader = full_train_dataloader
+        self.arnoldi_projectors = []
+
+        # Assuming that full_train_dataloader has only one batch
+        # TODO: support multiple batches
+        data_target_pair = next(iter(full_train_dataloader))
+        func = partial(self.task.get_loss_func(), data_target_pair=data_target_pair)
+
         from dattri.func.projection import arnoldi_project
 
-        if not hasattr(self, "arnoldi_projector"):
-            feature_dim = query.shape[1]
-            func = partial(self.task.get_loss_func(), data_target_pair=train_data)
-            model_params, _ = self.task.get_param(index)
-            self.arnoldi_projector = arnoldi_project(
-                feature_dim,
-                func,
-                model_params,
-                device=self.device,
-                **transformation_kwargs,
+        for i in range(len(self.task.get_checkpoints())):
+            model_params, _ = self.task.get_param(i)
+            self.arnoldi_projectors.append(
+                arnoldi_project(
+                    feature_dim=len(model_params),
+                    func=func,
+                    x=model_params,
+                    proj_dim=self.proj_dim,
+                    max_iter=self.max_iter,
+                    norm_constant=self.norm_constant,
+                    tol=self.tol,
+                    regularization=self.regularization,
+                    seed=self.seed,
+                    device=self.device,
+                ),
             )
 
-        return self.arnoldi_projector(query).detach()
+    def transform_train_rep(
+        self,
+        ckpt_idx: int,
+        train_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Transform the train representations via Arnoldi projection.
+
+        Args:
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            train_rep (torch.Tensor): The train representations to be transformed.
+                It is a 2-d dimensional tensor with the shape of
+                (batch_size, num_params).
+
+        Returns:
+            torch.Tensor: The transformed train representations, a 2-d dimensional
+                tensor with the shape of (batch_size, proj_dim).
+        """
+        return self.arnoldi_projectors[ckpt_idx](train_rep).detach()
+
+    def transform_test_rep(
+        self,
+        ckpt_idx: int,
+        test_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Transform the test representations via Arnoldi projection.
+
+        Args:
+            ckpt_idx (int): The index of the model checkpoints. This index
+                is used for ensembling different trained model checkpoints.
+            test_rep (torch.Tensor): The test representations to be transformed.
+                It is a 2-d dimensional tensor with the shape of
+                (batch_size, num_params).
+
+        Returns:
+            torch.Tensor: The transformed test representations, a 2-d dimensional
+                tensor with the shape of (batch_size, proj_dim).
+        """
+        return self.arnoldi_projectors[ckpt_idx](test_rep).detach()
 
 
 class IFAttributorLiSSA(BaseInnerProductAttributor):
     """The inner product attributor with LiSSA inverse hessian transformation."""
 
-    def transformation_on_query(
+    def __init__(
         self,
-        index: int,
-        train_data: Tuple[torch.Tensor, ...],
-        query: torch.Tensor,
-        **transformation_kwargs,
-    ) -> torch.Tensor:
-        """Calculate the transformation on the query through ihvp_lissa.
+        task: AttributionTask,
+        device: Optional[str] = "cpu",
+        batch_size: int = 1,
+        num_repeat: int = 1,
+        recursion_depth: int = 5000,
+        damping: int = 0.0,
+        scaling: int = 50.0,
+        mode: str = "rev-rev",
+    ) -> None:
+        """Initialize the LiSSA inverse hessian attributor.
 
         Args:
-            index (int): The index of the model parameters. This index
+            task (AttributionTask): The task to be attributed. The task should
+                be an instance of `AttributionTask`.
+            device (str): The device to run the attributor. Default is cpu.
+            batch_size (int): An integer default to 1. Specifies the batch size used
+                for LiSSA inner loop update.
+            num_repeat (int): An integer default to 1. Specifies the number of samples
+                of the hvp approximation to average on.
+            recursion_depth (int): A integer default to 5000. Specifies the number of
+                recursions used to estimate each IHVP sample.
+            damping (int): Damping factor used for non-convexity in LiSSA IHVP
+                calculation.
+            scaling (int): Scaling factor used for convergence in LiSSA IHVP
+                calculation.
+            mode (str): The auto diff mode, which can have one of the following values:
+                - rev-rev: calculate the hessian with two reverse-mode auto-diff. It has
+                        better compatibility while cost more memory.
+                - rev-fwd: calculate the hessian with the composing of reverse-mode and
+                        forward-mode. It's more memory-efficient but may not be
+                        supported by some operator.
+        """
+        super().__init__(task, device)
+        self.transformation_kwargs = {
+            "batch_size": batch_size,
+            "num_repeat": num_repeat,
+            "recursion_depth": recursion_depth,
+            "damping": damping,
+            "scaling": scaling,
+            "mode": mode,
+        }
+
+    def transform_test_rep(
+        self,
+        ckpt_idx: int,
+        test_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Calculate the transformation on the test rep through ihvp_lissa.
+
+        Args:
+            ckpt_idx (int): The index of the model parameters. This index
                 is used for ensembling of different trained model.
-            train_data (Tuple[Tensor]): The train data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
-            query (torch.Tensor): The query to be transformed. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
-            transformation_kwargs (Dict[str, Any]): The keyword arguments for
-                the transformation function.
+            test_rep (torch.Tensor): The test representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
 
         Returns:
             torch.Tensor: The transformation on the query. Normally it is a 2-d
@@ -374,17 +549,22 @@ class IFAttributorLiSSA(BaseInnerProductAttributor):
         """
         from dattri.func.hessian import ihvp_lissa
 
-        self.ihvp_func = ihvp_lissa(
-            self.task.get_loss_func(),
-            collate_fn=IFAttributorLiSSA.lissa_collate_fn,
-            **transformation_kwargs,
-        )
-        model_params, _ = self.task.get_param(index)
-        return self.ihvp_func(
-            (model_params, *train_data),
-            query,
-            in_dims=(None,) + (0,) * len(train_data),
-        ).detach()
+        vector_product = 0
+        model_params, _ = self.task.get_param(ckpt_idx)
+        for full_data_ in self.full_train_dataloader:
+            # move to device
+            full_data = tuple(data.to(self.device) for data in full_data_)
+            self.ihvp_func = ihvp_lissa(
+                self.task.get_loss_func(),
+                collate_fn=IFAttributorLiSSA.lissa_collate_fn,
+                **self.transformation_kwargs,
+            )
+            vector_product += self.ihvp_func(
+                (model_params, *full_data),
+                test_rep,
+                in_dims=(None,) + (0,) * len(full_data),
+            ).detach()
+        return vector_product
 
     @staticmethod
     def lissa_collate_fn(
@@ -407,27 +587,42 @@ class IFAttributorLiSSA(BaseInnerProductAttributor):
 class IFAttributorDataInf(BaseInnerProductAttributor):
     """The inner product attributor with DataInf inverse hessian transformation."""
 
-    def transformation_on_query(
+    def __init__(
         self,
-        index: int,
-        train_data: Tuple[torch.Tensor, ...],
-        query: torch.Tensor,
-        **transformation_kwargs,
+        task: AttributionTask,
+        device: Optional[str] = "cpu",
+        regularization: float = 0.0,
+    ) -> None:
+        """Initialize the explicit inverse hessian attributor.
+
+        Args:
+            task (AttributionTask): The task to be attributed. The task should
+                be an instance of `AttributionTask`.
+            device (str): The device to run the attributor. Default is cpu.
+            regularization (float): A float default to 0.0. Specifies the regularization
+                term to be added to the Hessian vector product, which is useful for the
+                later inverse calculation if the Hessian matrix is singular or
+                ill-conditioned. Specifically, the regularization term is
+                `regularization * v`.
+        """
+        super().__init__(task, device)
+        self.transformation_kwargs = {
+            "regularization": regularization,
+        }
+
+    def transform_test_rep(
+        self,
+        ckpt_idx: int,
+        test_rep: torch.Tensor,
     ) -> torch.Tensor:
         """Calculate the transformation on the query through ifvp_datainf.
 
         Args:
-            index (int): The index of the model parameters. This index
+            ckpt_idx (int): The index of the model parameters. This index
                 is used for ensembling of different trained model.
-            train_data (Tuple[Tensor]): The train data. Normally this is a tuple
-                of input data and target data, the number of items in the
-                tuple should be aligned in the target function. The tensors'
-                shape follows (1, batchsize, ...).
-            query (torch.Tensor): The query to be transformed. Normally it is
-                a 2-d dimensional tensor with the shape of
-                (batchsize, num_parameters).
-            transformation_kwargs (Dict[str, Any]): The keyword arguments for
-                the transformation function.
+            test_rep (torch.Tensor): The test representations to be transformed.
+                Typically, it is a 2-d dimensional tensor with the shape of
+                (batch_size, num_parameters).
 
         Returns:
             torch.Tensor: The transformation on the query. Normally it is a 2-d
@@ -435,14 +630,14 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
         """
         from dattri.func.fisher import ifvp_datainf
 
-        model_params, param_layer_map = self.task.get_param(index, layer_split=True)
+        model_params, param_layer_map = self.task.get_param(ckpt_idx, layer_split=True)
 
         self.ihvp_func = ifvp_datainf(
             self.task.get_loss_func(),
             0,
             (None, 0),
             param_layer_map=param_layer_map,
-            **transformation_kwargs,
+            **self.transformation_kwargs,
         )
 
         split_index = [0] * (param_layer_map[-1] + 1)
@@ -452,11 +647,16 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
         current_idx = 0
         query_split = []
         for i in range(len(split_index)):
-            query_split.append(query[:, current_idx : split_index[i] + current_idx])
+            query_split.append(test_rep[:, current_idx : split_index[i] + current_idx])
             current_idx += split_index[i]
 
-        res = self.ihvp_func(
-            (model_params, (train_data[0], train_data[1].view(-1, 1).float())),
-            query_split,
-        )
-        return torch.cat(res, dim=1).detach()
+        vector_product = 0
+        for full_data_ in self.full_train_dataloader:
+            # move to device
+            full_data = tuple(data.to(self.device) for data in full_data_)
+            res = self.ihvp_func(
+                (model_params, (full_data[0], full_data[1].view(-1, 1).float())),
+                query_split,
+            )
+            vector_product += torch.cat(res, dim=1).detach()
+        return vector_product

--- a/test/dattri/algorithm/test_influence_function.py
+++ b/test/dattri/algorithm/test_influence_function.py
@@ -82,7 +82,6 @@ class TestInfluenceFunction:
         attributor.attribute(train_loader, test_loader)
 
         # DataInf
-        # lissa
         attributor = IFAttributorDataInf(
             task=task,
             device=torch.device("cpu"),


### PR DESCRIPTION
## Description

### 1. Motivation and Context
Revise the `BaseInnerProductAttributor` following the spirit of https://github.com/TRAIS-Lab/dattri/pull/130

### 2. Summary of the change

- transformation could now be applied to both train data representations/gradients and test data representations/gradients
- the batching over the full training data for transformation was original dealt inside .attribute() with a simple average, which lacks enough flexibility; it is now moved into the transform functions
- .cache() could do more than just storing the full training dataloader. For example, the Arnoldi projector is now processed in
- removed transformation_kwargs and added an init for the subclass. It's better to specify these attributor hyperparameters explicitly than relying on a kwargs


### 3. What tests have been added/updated for the change?
- [ ] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
