### PR TITLE
[dattri.func] Re-implementation of Arnoldi projector

### DIFF
--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -343,7 +343,7 @@ class BaseInnerProductAttributor(BaseAttributor):
 
                     tda_output[row_st:row_ed, col_st:col_ed] += (
                         train_batch_rep @ test_batch_rep.T
-                    ).to(torch.float)
+                    )
 
             tda_output /= checkpoint_idx + 1
 

--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -343,7 +343,7 @@ class BaseInnerProductAttributor(BaseAttributor):
 
                     tda_output[row_st:row_ed, col_st:col_ed] += (
                         train_batch_rep @ test_batch_rep.T
-                    )
+                    ).to(torch.float)
 
             tda_output /= checkpoint_idx + 1
 

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -480,6 +480,33 @@ class IFAttributorArnoldi(BaseInnerProductAttributor):
 
         return self.arnoldi_projectors[ckpt_idx](test_rep).detach()
 
+    def transform_train_rep(
+        self,
+        ckpt_idx: int,
+        train_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Transform the train representations via Arnoldi projection.
+
+        Args:
+            ckpt_idx (int): Index of the model checkpoints. Used for ensembling
+                different trained model checkpoints.
+            train_rep (torch.Tensor): Train representations to be transformed.
+                A 2-d tensor with shape (batch_size, num_params).
+
+        Returns:
+            torch.Tensor: Transformed train representations. A 2-d tensor with
+                shape (batch_size, proj_dim).
+
+        Raises:
+            ValueError: If the Arnoldi projector has not been cached.
+        """
+        if not hasattr(self, "arnoldi_projectors"):
+            error_msg = "The Arnoldi projector has not been cached.\
+                         Please call cache() first."
+            raise ValueError(error_msg)
+
+        return self.arnoldi_projectors[ckpt_idx](train_rep).detach()
+
 
 class IFAttributorLiSSA(BaseInnerProductAttributor):
     """The inner product attributor with LiSSA inverse hessian transformation."""

--- a/dattri/benchmark/datasets/mnist/mnist_mlp.py
+++ b/dattri/benchmark/datasets/mnist/mnist_mlp.py
@@ -69,6 +69,7 @@ def loss_mnist_mlp(
     model = create_mlp_model("mnist")
     model.load_state_dict(torch.load(Path(model_path)))
     model.eval()
+    model.to(device)
     loss_list = []
     with torch.no_grad():
         for inputs, labels in dataloader:

--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -769,10 +769,7 @@ class ArnoldiProjector(AbstractProjector):
         # have not compute the eigen space yet
         if self.eigvals is None or self.eigvecs is None:
             self.get_eigenspace()
-
-        return (
-            (features @ self.eigvecs.T) * 1.0 / self.eigvals.unsqueeze(0)
-        ) @ self.eigvecs
+        return features @ self.eigvecs.T * (1.0 / torch.sqrt(self.eigvals.unsqueeze(0)))
 
     def free_memory(self) -> None:
         """A no-op method."""

--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -769,6 +769,8 @@ class ArnoldiProjector(AbstractProjector):
         # have not compute the eigen space yet
         if self.eigvals is None or self.eigvecs is None:
             self.get_eigenspace()
+
+        self.eigvals = (self.eigvals).to(torch.complex64)
         return features @ self.eigvecs.T * (1.0 / torch.sqrt(self.eigvals.unsqueeze(0)))
 
     def free_memory(self) -> None:

--- a/dattri/func/projection.py
+++ b/dattri/func/projection.py
@@ -756,9 +756,9 @@ class ArnoldiProjector(AbstractProjector):
         self.eigvals, self.eigvecs = self._distill(appr_mat, proj, self.proj_dim)
 
         # prevent from negative eigvals
-        if self.proj_dim > torch.sum(self.eigvals > 0):
+        if self.proj_dim > torch.sum(self.eigvals > self.tol**2):
             # adjust proj_dim
-            self.proj_dim = torch.sum(self.eigvals > 0).item()
+            self.proj_dim = torch.sum(self.eigvals > self.tol**2).item()
             warnings.warn(
                 "Encountered many negative eigenvalues and `proj_dim` is greater"
                 " than the number of positive eigenvalues. Automatically adjusting"

--- a/test/dattri/func/test_proj.py
+++ b/test/dattri/func/test_proj.py
@@ -152,12 +152,14 @@ class TestArnoldiProjector(unittest.TestCase):
             return torch.sin(x).sum()
 
         x = torch.randn(self.feature_dim)
-
+        # set reg large enough to have some positive eigvals
+        reg = 1.0
         self.projector = ArnoldiProjector(
             self.feature_dim,
             self.proj_dim,
             target,
             x,
+            regularization=reg,
         )
 
         vec1 = torch.randn(self.vec_dim, self.feature_dim)
@@ -167,8 +169,8 @@ class TestArnoldiProjector(unittest.TestCase):
 
         # test the closeness of inner product only
         assert torch.allclose(
-            (projected_grads1 @ projected_grads2.T).to(torch.float),
-            (vec1 @ torch.diag(-1 / x.sin())) @ vec2.T,
+            (projected_grads1 @ projected_grads2.T),
+            (vec1 @ (torch.diag(1 / (reg - x.sin())))) @ vec2.T,
             rtol=1e-01,
             atol=1e-04,
         )

--- a/test/dattri/func/test_proj.py
+++ b/test/dattri/func/test_proj.py
@@ -540,7 +540,7 @@ class TestGetProjection(unittest.TestCase):
 
         result = projector(vec)
 
-        assert result.shape == (vec_dim, feature_dim)
+        assert result.shape == (vec_dim, proj_dim)
 
 
 if __name__ == "__main__":

--- a/test/dattri/func/test_proj.py
+++ b/test/dattri/func/test_proj.py
@@ -160,16 +160,21 @@ class TestArnoldiProjector(unittest.TestCase):
             x,
         )
 
-        vec = torch.randn(self.vec_dim, self.feature_dim)
-        projected_grads = self.projector.project(vec)
+        vec1 = torch.randn(self.vec_dim, self.feature_dim)
+        vec2 = torch.randn(self.vec_dim, self.feature_dim)
+        projected_grads1 = self.projector.project(vec1)
+        projected_grads2 = self.projector.project(vec2)
 
+        # test the closeness of inner product only
         assert torch.allclose(
-            projected_grads,
-            (torch.diag(-1 / x.sin()) @ vec.T).T,
+            (projected_grads1 @ projected_grads2.T).to(torch.float),
+            (vec1 @ torch.diag(-1 / x.sin())) @ vec2.T,
             rtol=1e-01,
             atol=1e-04,
         )
-        assert projected_grads.shape == (self.vec_dim, self.feature_dim)
+        # test the shape
+        assert projected_grads1.shape == (self.vec_dim, self.feature_dim)
+        assert projected_grads2.shape == (self.vec_dim, self.feature_dim)
 
 
 class SmallModel(nn.Module):


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context

Re-define the arnoldi projector as 1.0 / sqrt(eigvals) * eigvecs.T * features
<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

### 2. Summary of the change
- fix the `arnoldi_project`
- add `transform_train_rep` inside arnoldi attributor
- fix a slight typo found in `dattri/benchmark/datasets/mnist/mnist_mlp`
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. What tests have been added/updated for the change?
- [x] Application test: If you wrote an example for the toolkit, this test should be added.

