### PR TITLE
[dattri.algorithm] add partial parameters support for IF, TracIN, Grad-Dot/Cos, TRAK

### DIFF
--- a/dattri/algorithm/tracin.py
+++ b/dattri/algorithm/tracin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import List, Optional, Union
 
     from dattri.task import AttributionTask
 
@@ -29,6 +29,7 @@ class TracInAttributor(BaseAttributor):
         weight_list: Tensor,
         normalized_grad: bool,
         projector_kwargs: Optional[Dict[str, Any]] = None,
+        layer_name: Optional[Union[str, List[str]]] = None,
         device: str = "cpu",
     ) -> None:
         """Initialize the TracIn attributor.
@@ -42,6 +43,11 @@ class TracInAttributor(BaseAttributor):
             normalized_grad (bool): Whether to apply normalization to gradients.
             projector_kwargs (Optional[Dict[str, Any]]): The keyword arguments for the
                 projector.
+            layer_name (Optional[Union[str, List[str]]]): The name of the layer to be
+                used to calculate the train/test representations. If None, full
+                parameters are used. This should be a string or a list of strings
+                if multiple layers are needed. The name of layer should follow the
+                key of model.named_parameters(). Default: None.
             device (str): The device to run the attributor. Default is cpu.
         """
         self.task = task
@@ -52,6 +58,7 @@ class TracInAttributor(BaseAttributor):
         if projector_kwargs is not None:
             self.proj_seed = self.projector_kwargs.get("proj_seed", 0)
         self.normalized_grad = normalized_grad
+        self.layer_name = layer_name
         self.device = device
         self.full_train_dataloader = None
         # to get per-sample gradients for a mini-batch of train/test samples
@@ -104,7 +111,21 @@ class TracInAttributor(BaseAttributor):
             range(len(self.task.get_checkpoints())),
             self.weight_list,
         ):
-            parameters, _ = self.task.get_param(index=ckpt_index)
+            parameters, _ = self.task.get_param(
+                index=ckpt_index,
+                layer_name=self.layer_name,
+            )
+            if self.layer_name is not None:
+                self.grad_target_func = self.task.get_grad_target_func(
+                    in_dims=(None, 0),
+                    layer_name=self.layer_name,
+                    index=ckpt_index,
+                )
+                self.grad_loss_func = self.task.get_grad_loss_func(
+                    in_dims=(None, 0),
+                    layer_name=self.layer_name,
+                    index=ckpt_index,
+                )
 
             for train_batch_idx, train_batch_data_ in enumerate(
                 tqdm(

--- a/dattri/algorithm/tracin.py
+++ b/dattri/algorithm/tracin.py
@@ -107,24 +107,24 @@ class TracInAttributor(BaseAttributor):
         )
 
         # iterate over each checkpoint (each ensemble)
-        for ckpt_index, ckpt_weight in zip(
+        for ckpt_idx, ckpt_weight in zip(
             range(len(self.task.get_checkpoints())),
             self.weight_list,
         ):
             parameters, _ = self.task.get_param(
-                index=ckpt_index,
+                index=ckpt_idx,
                 layer_name=self.layer_name,
             )
             if self.layer_name is not None:
                 self.grad_target_func = self.task.get_grad_target_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_index,
+                    index=ckpt_idx,
                 )
                 self.grad_loss_func = self.task.get_grad_loss_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_index,
+                    index=ckpt_idx,
                 )
 
             for train_batch_idx, train_batch_data_ in enumerate(
@@ -151,7 +151,7 @@ class TracInAttributor(BaseAttributor):
                     # param index as ensemble id
                     train_batch_grad = self.train_random_project(
                         torch.nan_to_num(grad_t),
-                        ensemble_id=ckpt_index,
+                        ensemble_id=ckpt_idx,
                     )
                 else:
                     train_batch_grad = torch.nan_to_num(grad_t)
@@ -179,7 +179,7 @@ class TracInAttributor(BaseAttributor):
 
                         test_batch_grad = self.test_random_project(
                             torch.nan_to_num(grad_t),
-                            ensemble_id=ckpt_index,
+                            ensemble_id=ckpt_idx,
                         )
                     else:
                         test_batch_grad = torch.nan_to_num(grad_t)

--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -102,22 +102,22 @@ class TRAKAttributor(BaseAttributor):
         inv_XTX_XT_list = []
         running_Q = 0
         running_count = 0
-        for ckpt_seed in range(len(self.task.get_checkpoints())):
+        for ckpt_idx in range(len(self.task.get_checkpoints())):
             parameters, _ = self.task.get_param(
-                index=ckpt_seed,
+                index=ckpt_idx,
                 layer_name=self.layer_name,
             )
-            full_parameters, _ = self.task.get_param(index=ckpt_seed)
+            full_parameters, _ = self.task.get_param(index=ckpt_idx)
             if self.layer_name is not None:
                 self.grad_target_func = self.task.get_grad_target_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_seed,
+                    index=ckpt_idx,
                 )
                 self.grad_loss_func = self.task.get_grad_loss_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_seed,
+                    index=ckpt_idx,
                 )
 
             full_train_projected_grad = []
@@ -136,7 +136,7 @@ class TRAKAttributor(BaseAttributor):
                         grad_t,
                         train_batch_data[0].shape[0],
                         **self.projector_kwargs,
-                    )(grad_t, ensemble_id=ckpt_seed)
+                    )(grad_t, ensemble_id=ckpt_idx)
                     .clone()
                     .detach()
                 )
@@ -213,22 +213,22 @@ class TRAKAttributor(BaseAttributor):
                        did not cache a training loader by .cache(). Please provide a\
                        training loader or cache a training loader."
             raise ValueError(message)
-        for ckpt_seed in range(len(self.task.get_checkpoints())):
+        for ckpt_idx in range(len(self.task.get_checkpoints())):
             parameters, _ = self.task.get_param(
-                index=ckpt_seed,
+                index=ckpt_idx,
                 layer_name=self.layer_name,
             )
-            full_parameters, _ = self.task.get_param(index=ckpt_seed)
+            full_parameters, _ = self.task.get_param(index=ckpt_idx)
             if self.layer_name is not None:
                 self.grad_target_func = self.task.get_grad_target_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_seed,
+                    index=ckpt_idx,
                 )
                 self.grad_loss_func = self.task.get_grad_loss_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_seed,
+                    index=ckpt_idx,
                 )
 
             if train_dataloader is not None:
@@ -254,7 +254,7 @@ class TRAKAttributor(BaseAttributor):
                             grad_t,
                             train_batch_data[0].shape[0],
                             **self.projector_kwargs,
-                        )(grad_t, ensemble_id=ckpt_seed)
+                        )(grad_t, ensemble_id=ckpt_idx)
                         .clone()
                         .detach()
                     )
@@ -292,7 +292,7 @@ class TRAKAttributor(BaseAttributor):
                         grad_t,
                         test_batch_data[0].shape[0],
                         **self.projector_kwargs,
-                    )(grad_t, ensemble_id=ckpt_seed)
+                    )(grad_t, ensemble_id=ckpt_idx)
                     .clone()
                     .detach()
                 )
@@ -309,7 +309,7 @@ class TRAKAttributor(BaseAttributor):
             else:
                 running_xinv_XTX_XT = (
                     running_xinv_XTX_XT * running_count
-                    + test_projected_grad @ self.inv_XTX_XT_list[ckpt_seed]
+                    + test_projected_grad @ self.inv_XTX_XT_list[ckpt_idx]
                 )
 
             if train_dataloader is not None:

--- a/dattri/func/utils.py
+++ b/dattri/func/utils.py
@@ -324,8 +324,13 @@ def partial_param(
         @functools.wraps(function)
         def _function_partial(*args, **kwargs: Dict[str, Any]) -> torch.Tensor:
             new_args = list(args)
-            for i, layer in enumerate(layer_name):
-                full_param[layer] = new_args[param_num][i]
+            index_counter = 0
+            for layer in layer_name:
+                length_param = full_param[layer].numel()
+                full_param[layer] = new_args[param_num][
+                    index_counter : index_counter + length_param
+                ]
+                index_counter += length_param
             new_args[param_num] = flatten_params(full_param)
             return function(*new_args, **kwargs)
 

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -176,7 +176,11 @@ class AttributionTask:
                 If the input is a scalar, the corresponding element should be None.
                 If the input is a tensor, the corresponding element should be the
                 dimension of the tensor.
-            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+            layer_name (Optional[Union[str, List[str]]]): The name of the layer as
+                to calculate the gradient w.r.t. If None, all the parameters
+                will be used to calcluate the gradient of target func. This should be
+                a string or a list of strings if multiple layers are needed. The name
+                of layer should follow the key of model.named_parameters().
             index (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
@@ -214,7 +218,11 @@ class AttributionTask:
 
         Args:
             flatten (bool): If True, the target function will be flattened.
-            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+            layer_name (Optional[Union[str, List[str]]]): The name of the layer as
+                the input to calculate the target func. If None, all the parameters
+                will be used as input of the target func. This should be
+                a string or a list of strings if multiple layers are needed. The name
+                of layer should follow the key of model.named_parameters().
             index (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
@@ -255,7 +263,11 @@ class AttributionTask:
                 If the input is a scalar, the corresponding element should be None.
                 If the input is a tensor, the corresponding element should be the
                 dimension of the tensor.
-            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+            layer_name (Optional[Union[str, List[str]]]): The name of the layer as
+                to calculate the gradient w.r.t. If None, all the parameters
+                will be used to calcluate the gradient of loss. This should be
+                a string or a list of strings if multiple layers are needed. The name
+                of layer should follow the key of model.named_parameters().
             index (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
@@ -292,7 +304,11 @@ class AttributionTask:
 
         Args:
             flatten (bool): If True, the loss function will be flattened.
-            layer_name (Optional[Union[str, List[str]]]): This has not been supported.
+            layer_name (Optional[Union[str, List[str]]]): The name of the layer as
+                the input to calculate the loss. If None, all the parameters
+                will be used as input of the loss func. This should be
+                a string or a list of strings if multiple layers are needed. The name
+                of layer should follow the key of model.named_parameters().
             index (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
@@ -329,9 +345,7 @@ class AttributionTask:
             layer_name (Optional[Union[str, List[str]]]): The name of the layer to be
                 extracted. If None, all the parameters will be returned. This should be
                 a string or a list of strings if multiple layers are needed. The name
-                of layer should follow the key of model.named_parameters(). If not None,
-                the layer_split will be forced to be True because a whole flattened
-                parameter will miss the layer information.
+                of layer should follow the key of model.named_parameters().
             layer_split (Optional[bool]): If True, the parameters will be split
                 into different layers and returned as a list of parameter tensors.
             param_layer_map (Optional[List[int]]): The map from the parameter
@@ -353,20 +367,18 @@ class AttributionTask:
         """
         self._load_checkpoints(index)
 
-        if layer_name:
+        if layer_name is not None:
             named_parameters = {
                 k: self.named_parameters[k]
                 for k in layer_name
                 if k in self.named_parameters
             }
-            # forced to layer_split
-            layer_split = True
         else:
             named_parameters = self.named_parameters
 
         if layer_split:
             if param_layer_map:
-                if len(param_layer_map) == len(
+                if len(param_layer_map) != len(
                     named_parameters,
                 ):
                     error_msg = (

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -167,8 +167,6 @@ class AttributionTask:
     ) -> Callable:
         """Return a function that computes the gradient of the target function.
 
-        TODO: support partial parameter gradient.
-
         Args:
             in_dims (Tuple[Union[None, int], ...]): The input dimensions of the target
                 function. This should be a tuple of integers and None. The length of the
@@ -214,8 +212,6 @@ class AttributionTask:
     ) -> Callable:
         """Return a function that computes the target function.
 
-        TODO: support partial parameter gradient.
-
         Args:
             flatten (bool): If True, the target function will be flattened.
             layer_name (Optional[Union[str, List[str]]]): The name of the layer as
@@ -253,8 +249,6 @@ class AttributionTask:
         index: Optional[int] = None,
     ) -> Callable:
         """Return a function that computes the gradient of the loss function.
-
-        TODO: support partial parameter gradient.
 
         Args:
             in_dims (Tuple[Union[None, int], ...]): The input dimensions of the loss
@@ -300,8 +294,6 @@ class AttributionTask:
     ) -> Callable:
         """Return a function that computes the gradient of the loss function.
 
-        TODO: support partial parameter gradient.
-
         Args:
             flatten (bool): If True, the loss function will be flattened.
             layer_name (Optional[Union[str, List[str]]]): The name of the layer as
@@ -342,24 +334,32 @@ class AttributionTask:
 
         Args:
             index (int): The index of the checkpoint to be loaded.
-            layer_name (Optional[Union[str, List[str]]]): The name of the layer to be
-                extracted. If None, all the parameters will be returned. This should be
+            layer_name (Optional[Union[str, List[str]]]): layer_name is used when
+                only a portion of the parameters are needed to be extracted. It
+                declares the parameters belonging to which layers will be extracted.
+                If None, all the parameters will be returned. This should be
                 a string or a list of strings if multiple layers are needed. The name
                 of layer should follow the key of model.named_parameters().
-            layer_split (Optional[bool]): If True, the parameters will be split
-                into different layers and returned as a list of parameter tensors.
-            param_layer_map (Optional[List[int]]): The map from the parameter
-                to the layer. If None, the map will be generated automatically. Normally
-                this should not be stated explicitly by the user, if needed it should
-                be the same length as parameters tuple. For example,
-                for a two layer model, params = (0.weights1, 0.bias, 1.weights, 1.bias),
-                param_layer_map should be [0, 0, 1, 1],resulting in two layers
-                as expected.
+                Default is None.
+            layer_split (Optional[bool]): layer_split is used when the returned
+                parameters need to be split by layers. If True, the return value of
+                this function will be a tuple of parameters where each element is
+                the parameters of a layer. If False, the return value will be a
+                flattened tensor of all the parameters. Default is False.
+            param_layer_map (Optional[List[int]]): A map stating the which element
+                of the parameter tuple belongs to which layer. It is only used when
+                layer_split is True. Default to None, which means the map will be
+                generated automatically. If param_layer_map is explicitly set, it
+                should have the same length as the named_parameters. For example,
+                for two layer model, params = (0.weights1, 0.bias, 1.weights, 1.bias),
+                param_layer_map should be [0, 0, 1, 1]. The explicitly set value will
+                be returned directly.
 
         Returns:
-            Tuple[Union[torch.Tensor, List[torch.Tensor]], Optional[List[int]]]: The
-                flattened parameters of the model and the layer map if layer_split
-                is True. Flattened parameters will be a 1-dim tensor.
+            Tuple[Union[torch.Tensor, List[torch.Tensor]], Optional[List[int]]]: If
+                layer_split is True, the return value will be a tuple of the parameters
+                of each layer and the param_layer_map. If layer_split is False, the
+                return value will be aflattened parameter of the model and None.
 
         Raises:
             ValueError: If the length of param_layer_map is not the same as the length

--- a/test/dattri/algorithm/test_influence_function.py
+++ b/test/dattri/algorithm/test_influence_function.py
@@ -54,16 +54,6 @@ class TestInfluenceFunction:
         attributor.cache(train_loader)
         attributor.attribute(train_loader, test_loader)
 
-        # Explicit w/ layer_name
-        attributor = IFAttributorExplicit(
-            task=task,
-            layer_name=["linear.weight"],
-            device=torch.device("cpu"),
-            regularization=1e-3,
-        )
-        attributor.cache(train_loader)
-        attributor.attribute(train_loader, test_loader)
-
         # CG
         attributor = IFAttributorCG(
             task=task,
@@ -97,6 +87,74 @@ class TestInfluenceFunction:
             task=task,
             device=torch.device("cpu"),
             regularization=1e-3,
+        )
+        attributor.cache(train_loader)
+        attributor.attribute(train_loader, test_loader)
+
+    def test_influence_function_partial_param(self):
+        """Test for influence function."""
+        train_dataset = TensorDataset(
+            torch.randn(20, 1, 28, 28),
+            torch.randint(0, 10, (20,)),
+        )
+        test_dataset = TensorDataset(
+            torch.randn(10, 1, 28, 28),
+            torch.randint(0, 10, (10,)),
+        )
+        train_loader = DataLoader(train_dataset, batch_size=4)
+        test_loader = DataLoader(test_dataset, batch_size=2)
+
+        model = train_mnist_lr(train_loader)
+
+        def f(params, data_target_pair):
+            image, label = data_target_pair
+            loss = nn.CrossEntropyLoss()
+            yhat = torch.func.functional_call(model, params, image)
+            return loss(yhat, label.long())
+
+        task = AttributionTask(
+            loss_func=f,
+            model=model,
+            checkpoints=model.state_dict(),
+        )
+
+        # Explicit w/ layer_name
+        attributor = IFAttributorExplicit(
+            task=task,
+            layer_name=["linear.weight"],
+            device=torch.device("cpu"),
+            regularization=1e-3,
+        )
+        attributor.cache(train_loader)
+        attributor.attribute(train_loader, test_loader)
+
+        # CG
+        attributor = IFAttributorCG(
+            task=task,
+            layer_name=["linear.weight"],
+            device=torch.device("cpu"),
+            regularization=1e-3,
+        )
+        attributor.cache(train_loader)
+        attributor.attribute(train_loader, test_loader)
+
+        # arnoldi
+        attributor = IFAttributorArnoldi(
+            task=task,
+            layer_name=["linear.weight"],
+            device=torch.device("cpu"),
+            regularization=1e-3,
+        )
+        attributor.cache(train_loader)
+        attributor.attribute(train_loader, test_loader)
+
+        # lissa
+        attributor = IFAttributorLiSSA(
+            task=task,
+            layer_name=["linear.weight"],
+            device=torch.device("cpu"),
+            recursion_depth=5,
+            batch_size=2,
         )
         attributor.cache(train_loader)
         attributor.attribute(train_loader, test_loader)

--- a/test/dattri/algorithm/test_influence_function.py
+++ b/test/dattri/algorithm/test_influence_function.py
@@ -54,6 +54,16 @@ class TestInfluenceFunction:
         attributor.cache(train_loader)
         attributor.attribute(train_loader, test_loader)
 
+        # Explicit w/ layer_name
+        attributor = IFAttributorExplicit(
+            task=task,
+            layer_name=["linear.weight"],
+            device=torch.device("cpu"),
+            regularization=1e-3,
+        )
+        attributor.cache(train_loader)
+        attributor.attribute(train_loader, test_loader)
+
         # CG
         attributor = IFAttributorCG(
             task=task,

--- a/test/dattri/test_task.py
+++ b/test/dattri/test_task.py
@@ -43,7 +43,6 @@ class TestTask:
             params_full, _ = task.get_param(index=0)
             gradient_partial = grad_func_partial(params_partial, train_batch_data)
             gradient_full = grad_func_full(params_full, train_batch_data)
-            gradient_partial = torch.cat(gradient_partial, dim=1)
             assert torch.allclose(
                 gradient_partial,
                 gradient_full[:, -gradient_partial.size(1) :],


### PR DESCRIPTION
## Description

### 1. Motivation and Context
This PR add partial parameters support for IF (except datainf), TracIN, Grad-Dot/Cos, TRAK. The main purpose is to reduce memory usage and make some TDA algorithms be able to scale to larger models.

### 2. Summary of the change
1. Add partial parameters support for IF, TracIN, Grad-Dot/Cos, TRAK
```python
attributor = Attributor(
    task=task,
    device=args.device,
    layer_name=["fc3.weight", "fc3.bias"],  # the only line changed
)
attributor.cache(train_loader_cache)
with torch.no_grad():
    score = attributor.attribute(train_loader, test_loader)
```

3. Revise the partial parameters in `AttributeTask` a little bit.
4. Add some docstring

I also did some experiment on Mnist+MLP setting. Only using `["fc3.weight", "fc3.bias"]`. (TRAK-10 used `["fc2.weight", "fc3.weight", "fc3.bias"]` to avoid singularity). The result of full parameter is on the left hand side of `->`.
| Method   | Time       | Mem         | LDS    |
|----------|------------|-------------|--------------|
| explicit | OOM->1'42  | OOM->9.6G   | OOM->0.153    |
| cg       | 3'14->3'11 | 7.1G->6.0G  | 0.259->0.132 |
| lissa    | 43.6->44.4 | 2.4G->1.3G  | 0.116->0.099 |
| arnoldi  | 33.4->34.3 | 1.4G->0.94G | 0.107->0.085 |
| grad-dot | 7.8->7.7   | 1.5G->0.9G  | 0.115->0.099 |
| TRAK-10  | 15.8->15.7 | 1.4G->1.0G  | 0.335->0.278 |

### 3. What tests have been added/updated for the change?
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
