### PR TITLE
[dattri.algorithm] relax the requirement to the `loss_func`.

### DIFF
--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -279,7 +279,7 @@ class IFAttributorExplicit(BaseInnerProductAttributor):
             self.ihvp_func = ihvp_explicit(
                 partial(
                     self.task.get_loss_func(layer_name=self.layer_name, index=ckpt_idx),
-                    data_target_pair=full_data,
+                    **{self.task.loss_func_data_key: full_data},
                 ),
                 **self.transformation_kwargs,
             )
@@ -360,7 +360,7 @@ class IFAttributorCG(BaseInnerProductAttributor):
             self.ihvp_func = ihvp_cg(
                 partial(
                     self.task.get_loss_func(layer_name=self.layer_name, index=ckpt_idx),
-                    data_target_pair=full_data,
+                    **{self.task.loss_func_data_key: full_data},
                 ),
                 **self.transformation_kwargs,
             )
@@ -461,7 +461,7 @@ class IFAttributorArnoldi(BaseInnerProductAttributor):
         for i in range(len(self.task.get_checkpoints())):
             func = partial(
                 self.task.get_loss_func(layer_name=self.layer_name, index=i),
-                data_target_pair=data_target_pair,
+                **{self.task.loss_func_data_key: data_target_pair},
             )
             model_params, _ = self.task.get_param(i, layer_name=self.layer_name)
             self.arnoldi_projectors.append(

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Dict, List, Optional, Tuple, Union
 
+import inspect
 from pathlib import PosixPath
 
 import torch
@@ -83,6 +84,9 @@ class AttributionTask:
 
         self.original_loss_func = loss_func
         self.loss_func = flatten_func(self.model)(loss_func)
+        signature_loss = inspect.signature(self.loss_func)
+        self.loss_func_data_key = list(signature_loss.parameters.keys())[1]
+
         self.original_target_func = target_func
         self.target_func = flatten_func(self.model)(target_func)
 


### PR DESCRIPTION
## Description

### 1. Motivation and Context

Currently, IF Attributors (CG, Explicit, Arnoldi) require the second parameter (data) of `loss_func` to be named as "data_target_pair". This PR relax this requirement.

### 2. Summary of the change

Inspect the loss function's signature and use it in the implementation of IF

### 3. What tests have been added/updated for the change?
- [ ] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
