### PR TITLE
[dattri.task] Rename index in task to ckpt_idx

### DIFF
--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -150,7 +150,7 @@ class BaseInnerProductAttributor(BaseAttributor):
         model_params, _ = self.task.get_param(ckpt_idx, layer_name=self.layer_name)
         return self.task.get_grad_target_func(
             layer_name=self.layer_name,
-            index=ckpt_idx,
+            ckpt_idx=ckpt_idx,
         )(model_params, data)
 
     def generate_train_rep(
@@ -182,10 +182,11 @@ class BaseInnerProductAttributor(BaseAttributor):
                 (batch_size, num_parameters).
         """
         model_params, _ = self.task.get_param(ckpt_idx, layer_name=self.layer_name)
-        return self.task.get_grad_loss_func(layer_name=self.layer_name, index=ckpt_idx)(
-            model_params,
-            data,
+        grad_loss_func = self.task.get_grad_loss_func(
+            layer_name=self.layer_name,
+            ckpt_idx=ckpt_idx,
         )
+        return grad_loss_func(model_params, data)
 
     def transform_test_rep(  # noqa: PLR6301
         self,

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -278,7 +278,10 @@ class IFAttributorExplicit(BaseInnerProductAttributor):
             full_data = tuple(data.to(self.device) for data in full_data_)
             self.ihvp_func = ihvp_explicit(
                 partial(
-                    self.task.get_loss_func(layer_name=self.layer_name, index=ckpt_idx),
+                    self.task.get_loss_func(
+                        layer_name=self.layer_name,
+                        ckpt_idx=ckpt_idx,
+                    ),
                     data_target_pair=full_data,
                 ),
                 **self.transformation_kwargs,
@@ -359,7 +362,10 @@ class IFAttributorCG(BaseInnerProductAttributor):
             full_data = tuple(data.to(self.device) for data in full_data_)
             self.ihvp_func = ihvp_cg(
                 partial(
-                    self.task.get_loss_func(layer_name=self.layer_name, index=ckpt_idx),
+                    self.task.get_loss_func(
+                        layer_name=self.layer_name,
+                        ckpt_idx=ckpt_idx,
+                    ),
                     data_target_pair=full_data,
                 ),
                 **self.transformation_kwargs,
@@ -460,7 +466,7 @@ class IFAttributorArnoldi(BaseInnerProductAttributor):
 
         for i in range(len(self.task.get_checkpoints())):
             func = partial(
-                self.task.get_loss_func(layer_name=self.layer_name, index=i),
+                self.task.get_loss_func(layer_name=self.layer_name, ckpt_idx=i),
                 data_target_pair=data_target_pair,
             )
             model_params, _ = self.task.get_param(i, layer_name=self.layer_name)
@@ -608,7 +614,7 @@ class IFAttributorLiSSA(BaseInnerProductAttributor):
             # move to device
             full_data = tuple(data.to(self.device) for data in full_data_)
             self.ihvp_func = ihvp_lissa(
-                self.task.get_loss_func(layer_name=self.layer_name, index=ckpt_idx),
+                self.task.get_loss_func(layer_name=self.layer_name, ckpt_idx=ckpt_idx),
                 collate_fn=IFAttributorLiSSA.lissa_collate_fn,
                 **self.transformation_kwargs,
             )

--- a/dattri/algorithm/rps.py
+++ b/dattri/algorithm/rps.py
@@ -60,7 +60,7 @@ class RPSAttributor(BaseAttributor):
         self.task = task
         self.target_func = task.get_target_func(flatten=False)
         self.model = task.get_model()
-        self.task.get_param(index=0)  # to load the checkpoint
+        self.task.get_param(ckpt_idx=0)  # to load the checkpoint
         self.final_linear_layer_name = final_linear_layer_name
         self.normalize_preactivate = normalize_preactivate
         self.l2_strength = l2_strength

--- a/dattri/algorithm/tracin.py
+++ b/dattri/algorithm/tracin.py
@@ -112,19 +112,19 @@ class TracInAttributor(BaseAttributor):
             self.weight_list,
         ):
             parameters, _ = self.task.get_param(
-                index=ckpt_idx,
+                ckpt_idx=ckpt_idx,
                 layer_name=self.layer_name,
             )
             if self.layer_name is not None:
                 self.grad_target_func = self.task.get_grad_target_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_idx,
+                    ckpt_idx=ckpt_idx,
                 )
                 self.grad_loss_func = self.task.get_grad_loss_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_idx,
+                    ckpt_idx=ckpt_idx,
                 )
 
             for train_batch_idx, train_batch_data_ in enumerate(

--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -72,7 +72,7 @@ class TRAKAttributor(BaseAttributor):
         """
         self.task = task
         self.norm_scaler = (
-            sum(p.numel() for p in self.task.get_param(index=0)[0]) ** 0.5
+            sum(p.numel() for p in self.task.get_param(ckpt_idx=0)[0]) ** 0.5
         )
         self.projector_kwargs = DEFAULT_PROJECTOR_KWARGS
         if projector_kwargs is not None:
@@ -104,20 +104,20 @@ class TRAKAttributor(BaseAttributor):
         running_count = 0
         for ckpt_idx in range(len(self.task.get_checkpoints())):
             parameters, _ = self.task.get_param(
-                index=ckpt_idx,
+                ckpt_idx=ckpt_idx,
                 layer_name=self.layer_name,
             )
-            full_parameters, _ = self.task.get_param(index=ckpt_idx)
+            full_parameters, _ = self.task.get_param(ckpt_idx=ckpt_idx)
             if self.layer_name is not None:
                 self.grad_target_func = self.task.get_grad_target_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_idx,
+                    ckpt_idx=ckpt_idx,
                 )
                 self.grad_loss_func = self.task.get_grad_loss_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_idx,
+                    ckpt_idx=ckpt_idx,
                 )
 
             full_train_projected_grad = []
@@ -215,20 +215,20 @@ class TRAKAttributor(BaseAttributor):
             raise ValueError(message)
         for ckpt_idx in range(len(self.task.get_checkpoints())):
             parameters, _ = self.task.get_param(
-                index=ckpt_idx,
+                ckpt_idx=ckpt_idx,
                 layer_name=self.layer_name,
             )
-            full_parameters, _ = self.task.get_param(index=ckpt_idx)
+            full_parameters, _ = self.task.get_param(ckpt_idx=ckpt_idx)
             if self.layer_name is not None:
                 self.grad_target_func = self.task.get_grad_target_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_idx,
+                    ckpt_idx=ckpt_idx,
                 )
                 self.grad_loss_func = self.task.get_grad_loss_func(
                     in_dims=(None, 0),
                     layer_name=self.layer_name,
-                    index=ckpt_idx,
+                    ckpt_idx=ckpt_idx,
                 )
 
             if train_dataloader is not None:

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -100,27 +100,30 @@ class AttributionTask:
         self.grad_loss_func_kwargs = {
             "in_dims": (None, 1),
             "layer_name": None,
-            "index": None,
+            "ckpt_idx": None,
         }
         self.grad_target_func = vmap(grad(self.target_func), in_dims=(None, 1))
         self.grad_target_func_kwargs = {
             "in_dims": (None, 1),
             "layer_name": None,
-            "index": None,
+            "ckpt_idx": None,
         }
 
-    def _load_checkpoints(self, index: int) -> None:
+    def _load_checkpoints(self, ckpt_idx: int) -> None:
         """This method load the checkpoint at the specified index.
 
         Args:
-            index (int): The index of the checkpoint to be loaded.
+            ckpt_idx (int): The index of the checkpoint to be loaded.
         """
-        if self.current_checkpoint_idx is None or self.current_checkpoint_idx != index:
-            if isinstance(self.checkpoints[index], (str, PosixPath)):
-                self.model.load_state_dict(torch.load(self.checkpoints[index]))
+        if (
+            self.current_checkpoint_idx is None
+            or self.current_checkpoint_idx != ckpt_idx
+        ):
+            if isinstance(self.checkpoints[ckpt_idx], (str, PosixPath)):
+                self.model.load_state_dict(torch.load(self.checkpoints[ckpt_idx]))
             else:
-                self.model.load_state_dict(self.checkpoints[index])
-            self.current_checkpoint_idx = index
+                self.model.load_state_dict(self.checkpoints[ckpt_idx])
+            self.current_checkpoint_idx = ckpt_idx
             self.named_parameters = {
                 k: p for k, p in self.model.named_parameters() if p.requires_grad
             }
@@ -163,7 +166,7 @@ class AttributionTask:
         self,
         in_dims: Tuple[Union[None, int], ...] = (None, 1),
         layer_name: Optional[Union[str, List[str]]] = None,
-        index: Optional[int] = None,
+        ckpt_idx: Optional[int] = None,
     ) -> Callable:
         """Return a function that computes the gradient of the target function.
 
@@ -179,7 +182,7 @@ class AttributionTask:
                 will be used to calcluate the gradient of target func. This should be
                 a string or a list of strings if multiple layers are needed. The name
                 of layer should follow the key of model.named_parameters().
-            index (Optional[int]): The index of the checkpoint to be loaded, only
+            ckpt_idx (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
         Returns:
@@ -188,7 +191,7 @@ class AttributionTask:
         # first add decorator that handles the layer_name
         target_func = self.target_func
         if layer_name is not None:
-            self._load_checkpoints(index)
+            self._load_checkpoints(ckpt_idx)
             target_func = partial_param(
                 full_param=self.named_parameters,
                 layer_name=layer_name,
@@ -197,7 +200,7 @@ class AttributionTask:
         grad_target_func_kwargs = {
             "in_dims": in_dims,
             "layer_name": layer_name,
-            "index": index,
+            "ckpt_idx": ckpt_idx,
         }
         if self.grad_target_func_kwargs != grad_target_func_kwargs:
             self.grad_target_func = vmap(grad(target_func), in_dims=in_dims)
@@ -208,7 +211,7 @@ class AttributionTask:
         self,
         flatten: bool = True,
         layer_name: Optional[Union[str, List[str]]] = None,
-        index: Optional[int] = None,
+        ckpt_idx: Optional[int] = None,
     ) -> Callable:
         """Return a function that computes the target function.
 
@@ -219,7 +222,7 @@ class AttributionTask:
                 will be used as input of the target func. This should be
                 a string or a list of strings if multiple layers are needed. The name
                 of layer should follow the key of model.named_parameters().
-            index (Optional[int]): The index of the checkpoint to be loaded, only
+            ckpt_idx (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
         Returns:
@@ -235,7 +238,7 @@ class AttributionTask:
             return self.original_target_func
 
         if layer_name is not None:
-            self._load_checkpoints(index)
+            self._load_checkpoints(ckpt_idx)
             return partial_param(
                 full_param=self.named_parameters,
                 layer_name=layer_name,
@@ -246,7 +249,7 @@ class AttributionTask:
         self,
         in_dims: Tuple[Union[None, int], ...] = (None, 1),
         layer_name: Optional[Union[str, List[str]]] = None,
-        index: Optional[int] = None,
+        ckpt_idx: Optional[int] = None,
     ) -> Callable:
         """Return a function that computes the gradient of the loss function.
 
@@ -262,7 +265,7 @@ class AttributionTask:
                 will be used to calcluate the gradient of loss. This should be
                 a string or a list of strings if multiple layers are needed. The name
                 of layer should follow the key of model.named_parameters().
-            index (Optional[int]): The index of the checkpoint to be loaded, only
+            ckpt_idx (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
         Returns:
@@ -270,7 +273,7 @@ class AttributionTask:
         """
         loss_func = self.loss_func
         if layer_name is not None:
-            self._load_checkpoints(index)
+            self._load_checkpoints(ckpt_idx)
             loss_func = partial_param(
                 full_param=self.named_parameters,
                 layer_name=layer_name,
@@ -279,7 +282,7 @@ class AttributionTask:
         loss_target_func_kwargs = {
             "in_dims": in_dims,
             "layer_name": layer_name,
-            "index": index,
+            "ckpt_idx": ckpt_idx,
         }
         if self.grad_loss_func_kwargs != loss_target_func_kwargs:
             self.grad_loss_func = vmap(grad(loss_func), in_dims=in_dims)
@@ -290,7 +293,7 @@ class AttributionTask:
         self,
         flatten: bool = True,
         layer_name: Optional[Union[str, List[str]]] = None,
-        index: Optional[int] = None,
+        ckpt_idx: Optional[int] = None,
     ) -> Callable:
         """Return a function that computes the gradient of the loss function.
 
@@ -301,7 +304,7 @@ class AttributionTask:
                 will be used as input of the loss func. This should be
                 a string or a list of strings if multiple layers are needed. The name
                 of layer should follow the key of model.named_parameters().
-            index (Optional[int]): The index of the checkpoint to be loaded, only
+            ckpt_idx (Optional[int]): The index of the checkpoint to be loaded, only
                 needed when layer_name is not None.
 
         Returns:
@@ -316,7 +319,7 @@ class AttributionTask:
                 raise NotImplementedError(error_msg)
             return self.original_loss_func
         if layer_name is not None:
-            self._load_checkpoints(index)
+            self._load_checkpoints(ckpt_idx)
             return partial_param(
                 full_param=self.named_parameters,
                 layer_name=layer_name,
@@ -325,7 +328,7 @@ class AttributionTask:
 
     def get_param(
         self,
-        index: int = 0,
+        ckpt_idx: int = 0,
         layer_name: Optional[Union[str, List[str]]] = None,
         layer_split: Optional[bool] = False,
         param_layer_map: Optional[List[int]] = None,
@@ -333,7 +336,7 @@ class AttributionTask:
         """Return the flattened parameter of the model.
 
         Args:
-            index (int): The index of the checkpoint to be loaded.
+            ckpt_idx (int): The index of the checkpoint to be loaded.
             layer_name (Optional[Union[str, List[str]]]): layer_name is used when
                 only a portion of the parameters are needed to be extracted. It
                 declares the parameters belonging to which layers will be extracted.
@@ -365,7 +368,7 @@ class AttributionTask:
             ValueError: If the length of param_layer_map is not the same as the length
                 of named_parameters
         """
-        self._load_checkpoints(index)
+        self._load_checkpoints(ckpt_idx)
 
         if layer_name is not None:
             named_parameters = {

--- a/test/dattri/test_task.py
+++ b/test/dattri/test_task.py
@@ -30,17 +30,17 @@ class TestTask:
 
         grad_func_partial = task.get_grad_loss_func(
             layer_name=["fc3.weight", "fc3.bias"],
-            index=0,
+            ckpt_idx=0,
         )
         grad_func_full = task.get_grad_loss_func()
 
         for train_batch_data_ in train_loader:
             train_batch_data = tuple(data.unsqueeze(0) for data in train_batch_data_)
             params_partial, _ = task.get_param(
-                index=0,
+                ckpt_idx=0,
                 layer_name=["fc3.weight", "fc3.bias"],
             )
-            params_full, _ = task.get_param(index=0)
+            params_full, _ = task.get_param(ckpt_idx=0)
             gradient_partial = grad_func_partial(params_partial, train_batch_data)
             gradient_full = grad_func_full(params_full, train_batch_data)
             assert torch.allclose(


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context

<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

We have set most checkpoint index variable as `ckpt_idx` for clarity but the variable names in task.py were still `index`.

### 2. Summary of the change

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

This PR renames `index` as `ckpt_idx` in task.py and the places where task is used.

### 3. What tests have been added/updated for the change?
- [X] N/A: No test will be added. No new functionality. Existing tests should suffice.
