### PR TITLE
[Document] support multiple document at the same time.

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,6 +27,15 @@ jobs:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/
-          force_orphan: tru
+          force_orphan: true
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main'}}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          destination_dir: ${{ github.ref_name }} # Use branch name as folder
+          force_orphan: false # Preserve existing files
       - uses: eviden-actions/clean-self-hosted-runner@v1
         if: ${{ always() }} # To ensure this step runs even when earlier steps fail

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,7 +4,7 @@ jobs:
   docs:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -27,8 +27,8 @@ jobs:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/
-          force_orphan: true
-      - name: Deploy
+          force_orphan: false
+      - name: Deploy-not-main
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main'}}
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,7 +4,7 @@ jobs:
   docs:
     permissions:
       contents: write
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION
## Description

### 1. Motivation and Context
We will have multiple document checkpoints for each released version as well as the latest version.

### 2. Summary of the change
Add a new step in `doc.yml` called Deploy-not-main. This will help us to have
1. The latest document (reflect the API of `main` branch) still show on `https://trais-lab.github.io/dattri`
2. The released version document will be shown on `https://trais-lab.github.io/dattri/<branch-name>`

### 3. What tests have been added/updated for the change?
- [ ] Document test: If you added an external API, then you should check if the document is correctly generated.