### PR TITLE
Implement RelatIF for Explicit, CG, and LISSA

### DIFF
--- a/dattri/algorithm/base.py
+++ b/dattri/algorithm/base.py
@@ -259,6 +259,7 @@ class BaseInnerProductAttributor(BaseAttributor):
         self,
         train_dataloader: DataLoader,
         test_dataloader: DataLoader,
+        relativeif_method: Optional[str] = None,
     ) -> torch.Tensor:
         """Calculate the influence of the training set on the test set.
 
@@ -270,6 +271,12 @@ class BaseInnerProductAttributor(BaseAttributor):
                 not be shuffled.
             test_dataloader (DataLoader): Dataloader for test samples to calculate
                 the influence. The dataloader should not be shuffled.
+            relativeif_method (Optional[str]): Method for normalizing the
+                influence values.
+                Supported options:
+                - `"l"`: Normalizes by `sqrt(g_i^T (H^-1 g_i))`.
+                - `"theta"`: Normalizes by `||H^-1 g_i||`.
+                - `None`: No normalization applied.
 
         Returns:
             torch.Tensor: The influence of the training set on the test set, with
@@ -314,6 +321,15 @@ class BaseInnerProductAttributor(BaseAttributor):
                     ckpt_idx=checkpoint_idx,
                     data=train_batch_data,
                 )
+
+                denom = None
+                if relativeif_method is not None:
+                    denom = self._compute_denom(
+                        checkpoint_idx,
+                        train_batch_rep,
+                        relativeif_method=relativeif_method,
+                    )
+
                 # transform the train representations
                 train_batch_rep = self.transform_train_rep(
                     ckpt_idx=checkpoint_idx,
@@ -356,9 +372,41 @@ class BaseInnerProductAttributor(BaseAttributor):
                     )
 
                     tda_output[row_st:row_ed, col_st:col_ed] += (
-                        train_batch_rep @ test_batch_rep.T
+                        train_batch_rep @ test_batch_rep.T / denom.unsqueeze(-1)
+                        if denom is not None
+                        else train_batch_rep @ test_batch_rep.T
                     )
 
             tda_output /= checkpoint_idx + 1
 
         return tda_output
+
+    def _compute_denom(
+        self,
+        ckpt_idx: int,  # noqa: ARG002
+        train_batch_rep: torch.Tensor,
+        relativeif_method: Optional[str] = None,  # noqa: ARG002
+    ) -> torch.Tensor:
+        """Compute the denominator for the influence calculation.
+
+        Args:
+            ckpt_idx (int): The index of the checkpoint being used for influence
+                calculation.
+            train_batch_rep (torch.Tensor): The representation of the training batch
+                at the given checkpoint.
+            relativeif_method (Optional[str]): Normalization method.
+                - `"l"`: Computes `sqrt(g_i^T (H^-1 g_i))`.
+                - `"theta"`: Computes `||H^-1 g_i||`.
+                - `None`: Raises an error.
+
+        Returns:
+            torch.Tensor: The computed denominator for normalization. It is a
+            1-d dimensional tensor with the shape of (batch_size).
+
+        Raises:
+            ValueError: If an unknown `method` is provided.
+        """
+        _ = self
+
+        batch_size = train_batch_rep.size(0)
+        return train_batch_rep.new_ones(batch_size)

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -289,6 +289,49 @@ class IFAttributorExplicit(BaseInnerProductAttributor):
             vector_product += self.ihvp_func((model_params,), test_rep).detach()
         return vector_product
 
+    def _compute_denom(
+        self,
+        ckpt_idx: int,
+        train_batch_rep: torch.Tensor,
+        relativeif_method: Optional[str] = None,
+    ) -> torch.Tensor:
+        """Compute the denominator for the influence calculation.
+
+        Args:
+            ckpt_idx (int): The index of the checkpoint being used for influence
+                calculation.
+            train_batch_rep (torch.Tensor): The representation of the training batch
+                at the given checkpoint.
+            relativeif_method (Optional[str]): Normalization method.
+                - `"l"`: Computes `sqrt(g_i^T (H^-1 g_i))`.
+                - `"theta"`: Computes `||H^-1 g_i||`.
+                - `None`: Raises an error.
+
+        Returns:
+            torch.Tensor: The computed denominator for normalization. It is a
+            1-d dimensional tensor with the shape of (batch_size).
+
+        Raises:
+            ValueError: If an unknown `method` is provided.
+        """
+        transformed = self.transform_test_rep(ckpt_idx, train_batch_rep)
+
+        if relativeif_method == "l":
+            # g_i^T (H^-1 g_i)
+            val = (
+                (self.transform_train_rep(ckpt_idx, train_batch_rep) * transformed)
+                .sum(dim=1)
+                .clamp_min(1e-12)
+                .sqrt()
+            )
+        elif relativeif_method == "theta":
+            # ||H^-1 g_i||
+            val = transformed.norm(dim=1).clamp_min(1e-12)
+        else:
+            error_msg = f"Unknown method: {relativeif_method}"
+            raise ValueError(error_msg)
+        return val
+
 
 class IFAttributorCG(BaseInnerProductAttributor):
     """The inner product attributor with CG inverse hessian transformation."""
@@ -372,6 +415,49 @@ class IFAttributorCG(BaseInnerProductAttributor):
             )
             vector_product += self.ihvp_func((model_params,), test_rep).detach()
         return vector_product
+
+    def _compute_denom(
+        self,
+        ckpt_idx: int,
+        train_batch_rep: torch.Tensor,
+        relativeif_method: Optional[str] = None,
+    ) -> torch.Tensor:
+        """Compute the denominator for the influence calculation.
+
+        Args:
+            ckpt_idx (int): The index of the checkpoint being used for influence
+                calculation.
+            train_batch_rep (torch.Tensor): The representation of the training batch
+                at the given checkpoint.
+            relativeif_method (Optional[str]): Normalization method.
+                - `"l"`: Computes `sqrt(g_i^T (H^-1 g_i))`.
+                - `"theta"`: Computes `||H^-1 g_i||`.
+                - `None`: Raises an error.
+
+        Returns:
+            torch.Tensor: The computed denominator for normalization. It is a
+            1-d dimensional tensor with the shape of (batch_size).
+
+        Raises:
+            ValueError: If an unknown `method` is provided.
+        """
+        transformed = self.transform_test_rep(ckpt_idx, train_batch_rep)
+
+        if relativeif_method == "l":
+            # g_i^T (H^-1 g_i)
+            val = (
+                (self.transform_train_rep(ckpt_idx, train_batch_rep) * transformed)
+                .sum(dim=1)
+                .clamp_min(1e-12)
+                .sqrt()
+            )
+        elif relativeif_method == "theta":
+            # ||H^-1 g_i||
+            val = transformed.norm(dim=1).clamp_min(1e-12)
+        else:
+            error_msg = f"Unknown method: {relativeif_method}"
+            raise ValueError(error_msg)
+        return val
 
 
 class IFAttributorArnoldi(BaseInnerProductAttributor):
@@ -642,6 +728,49 @@ class IFAttributorLiSSA(BaseInnerProductAttributor):
             tuple(sampled_input[i].float() for i in range(1, len(sampled_input))),
         )
 
+    def _compute_denom(
+        self,
+        ckpt_idx: int,
+        train_batch_rep: torch.Tensor,
+        relativeif_method: Optional[str] = None,
+    ) -> torch.Tensor:
+        """Compute the denominator for the influence calculation.
+
+        Args:
+            ckpt_idx (int): The index of the checkpoint being used for influence
+                calculation.
+            train_batch_rep (torch.Tensor): The representation of the training batch
+                at the given checkpoint.
+            relativeif_method (Optional[str]): Normalization method.
+                - `"l"`: Computes `sqrt(g_i^T (H^-1 g_i))`.
+                - `"theta"`: Computes `||H^-1 g_i||`.
+                - `None`: Raises an error.
+
+        Returns:
+            torch.Tensor: The computed denominator for normalization. It is a
+            1-d dimensional tensor with the shape of (batch_size).
+
+        Raises:
+            ValueError: If an unknown `method` is provided.
+        """
+        transformed = self.transform_test_rep(ckpt_idx, train_batch_rep)
+
+        if relativeif_method == "l":
+            # g_i^T (H^-1 g_i)
+            val = (
+                (self.transform_train_rep(ckpt_idx, train_batch_rep) * transformed)
+                .sum(dim=1)
+                .clamp_min(1e-12)
+                .sqrt()
+            )
+        elif relativeif_method == "theta":
+            # ||H^-1 g_i||
+            val = transformed.norm(dim=1).clamp_min(1e-12)
+        else:
+            error_msg = f"Unknown method: {relativeif_method}"
+            raise ValueError(error_msg)
+        return val
+
 
 class IFAttributorDataInf(BaseInnerProductAttributor):
     """The inner product attributor with DataInf inverse hessian transformation."""
@@ -690,21 +819,25 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
 
         for checkpoint_idx in range(len(self.task.get_checkpoints())):
             _cached_train_reps_list = []
-            iter_number = math.ceil(len(full_train_dataloader)
-                * self.fim_estimate_data_ratio)
+            iter_number = math.ceil(
+                len(full_train_dataloader) * self.fim_estimate_data_ratio,
+            )
             sampled_data_list = []
             for _ in range(iter_number):
                 sampled_data_list.append(next(iter(full_train_dataloader)))  # noqa: PERF401
             for sampled_data_ in sampled_data_list:
-                sampled_data = tuple(data.to(self.device).unsqueeze(0)
-                    for data in sampled_data_)
+                sampled_data = tuple(
+                    data.to(self.device).unsqueeze(0) for data in sampled_data_
+                )
                 sampled_data_rep = self.generate_train_rep(
                     ckpt_idx=checkpoint_idx,
                     data=sampled_data,
                 )
                 _cached_train_reps_list.append(sampled_data_rep)
             self._cached_train_reps[checkpoint_idx] = torch.cat(
-                _cached_train_reps_list, dim=0)
+                _cached_train_reps_list,
+                dim=0,
+            )
 
     def transform_test_rep(
         self,
@@ -758,8 +891,10 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
         regularization = self.regularization
         # Split layer-wise train and test representations
         test_rep_layers = self._get_layer_wise_reps(ckpt_idx, test_rep)
-        cached_train_rep_layers = self._get_layer_wise_reps(ckpt_idx,
-            self._cached_train_reps[ckpt_idx])
+        cached_train_rep_layers = self._get_layer_wise_reps(
+            ckpt_idx,
+            self._cached_train_reps[ckpt_idx],
+        )
         layer_cnt = len(cached_train_rep_layers)
         transformed_test_rep_layers = []
         # Use test batch size as intermediate batch size
@@ -771,16 +906,18 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
             length = grad_layer.shape[0]
             # Split gradients into smaller batches
             grad_batches = grad_layer.split(batch_size, dim=0)
-            running_transformation = torch.zeros(test_rep_layers[layer].shape,
-                device=test_rep_layers[layer].device)
+            running_transformation = torch.zeros(
+                test_rep_layers[layer].shape,
+                device=test_rep_layers[layer].device,
+            )
             for batch in grad_batches:
                 reg = 0.1 if regularization is None else regularization
                 contribution = torch.func.vmap(
                     lambda grad, layer=layer, reg=reg: _transform_single_test_rep(
-                    test_rep_layers[layer],
-                    grad,
-                    reg,
-                ),
+                        test_rep_layers[layer],
+                        grad,
+                        reg,
+                    ),
                 )(batch)
                 # Accumulate the batches and average at the end
                 running_transformation += contribution.sum(dim=0)
@@ -788,9 +925,11 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
             transformed_test_rep_layers.append(running_transformation)
         return torch.cat(transformed_test_rep_layers, dim=1)
 
-    def _get_layer_wise_reps(self,
+    def _get_layer_wise_reps(
+        self,
         ckpt_idx: int,
-        query: torch.Tensor) -> Tuple[torch.Tensor, ...]:
+        query: torch.Tensor,
+    ) -> Tuple[torch.Tensor, ...]:
         """Split a representation into layer-wise representations.
 
         Args:
@@ -804,7 +943,8 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
                 (batch_size,layer0_size), (batch_size,layer1_size)...
         """
         model_params, param_layer_map = self.task.get_param(
-            ckpt_idx, layer_split=True,
+            ckpt_idx,
+            layer_split=True,
         )
         split_index = [0] * (param_layer_map[-1] + 1)
         for idx, layer_index in enumerate(param_layer_map):
@@ -820,11 +960,12 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
 class IFAttributorEKFAC(BaseInnerProductAttributor):
     """The inner product attributor with EK-FAC inverse FIM transformation."""
 
-    def __init__(self,
-                 task: AttributionTask,
-                 module_name: Optional[Union[str, List[str]]] = None,
-                 device: Optional[str] = "cpu",
-                 damping: float = 0.0,
+    def __init__(
+        self,
+        task: AttributionTask,
+        module_name: Optional[Union[str, List[str]]] = None,
+        device: Optional[str] = "cpu",
+        damping: float = 0.0,
     ) -> None:
         """Initialize the EK-FAC inverse FIM attributor.
 
@@ -855,14 +996,17 @@ class IFAttributorEKFAC(BaseInnerProductAttributor):
         """
         super().__init__(task, None, device)
         if len(self.task.checkpoints) > 1:
-            error_msg = ("Received more than one checkpoint. "
-                         "Ensemble of EK-FAC is not supported.")
+            error_msg = (
+                "Received more than one checkpoint. "
+                "Ensemble of EK-FAC is not supported."
+            )
             raise ValueError(error_msg)
 
         if module_name is None:
             # Select all linear layers by default
             module_name = [
-                name for name, mod in self.task.model.named_modules()
+                name
+                for name, mod in self.task.model.named_modules()
                 if isinstance(mod, torch.nn.Linear)
             ]
         if not isinstance(module_name, list):
@@ -914,10 +1058,11 @@ class IFAttributorEKFAC(BaseInnerProductAttributor):
         if max_iter is None:
             max_iter = len(full_train_dataloader)
 
-        def _ekfac_hook(module: torch.nn.Module,
-                        inputs: Union[Tensor, Tuple[Tensor]],
-                        outputs: Union[Tensor, Tuple[Tensor]],
-            ) -> None:
+        def _ekfac_hook(
+            module: torch.nn.Module,
+            inputs: Union[Tensor, Tuple[Tensor]],
+            outputs: Union[Tensor, Tuple[Tensor]],
+        ) -> None:
             """Hook function for caching the inputs and outputs of a module.
 
             Args:
@@ -955,22 +1100,26 @@ class IFAttributorEKFAC(BaseInnerProductAttributor):
 
         func = partial(self.task.get_target_func(), self.task.get_param()[0])
         # 1. Use random batch to estimate covariance matrices S and A
-        cov_matrices = estimate_covariance(func,
-                                           full_train_dataloader,
-                                           self.layer_cache,
-                                           max_iter,
-                                           device=self.device)
+        cov_matrices = estimate_covariance(
+            func,
+            full_train_dataloader,
+            self.layer_cache,
+            max_iter,
+            device=self.device,
+        )
 
         # 2. Calculate the eigenvalue decomposition of S and A
         self.cached_q = estimate_eigenvector(cov_matrices)
 
         # 3. Use random batch for eigenvalue correction
-        self.cached_lambdas = estimate_lambda(func,
-                                              full_train_dataloader,
-                                              self.cached_q,
-                                              self.layer_cache,
-                                              max_iter,
-                                              device=self.device)
+        self.cached_lambdas = estimate_lambda(
+            func,
+            full_train_dataloader,
+            self.cached_q,
+            self.layer_cache,
+            max_iter,
+            device=self.device,
+        )
 
         # Remove hooks after preprocessing the FIM
         for handle in handles:
@@ -997,8 +1146,10 @@ class IFAttributorEKFAC(BaseInnerProductAttributor):
             ValueError: If specifies a non-zero `ckpt_idx`.
         """
         if ckpt_idx != 0:
-            error_msg = ("EK-FAC only supports single model checkpoint, "
-                         "but receives non-zero `ckpt_idx`.")
+            error_msg = (
+                "EK-FAC only supports single model checkpoint, "
+                "but receives non-zero `ckpt_idx`."
+            )
             raise ValueError(error_msg)
 
         # Unflatten the test_rep
@@ -1013,7 +1164,8 @@ class IFAttributorEKFAC(BaseInnerProductAttributor):
         for name, params in partial_model_params.items():
             size = math.prod(params.shape)
             layer_test_rep[name] = test_rep[
-                :, current_index : current_index + size,
+                :,
+                current_index : current_index + size,
             ].reshape(-1, *params.shape)
             current_index += size
 

--- a/examples/relatIF/influence_function_comparison.py
+++ b/examples/relatIF/influence_function_comparison.py
@@ -1,0 +1,191 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader, TensorDataset
+import numpy as np
+import matplotlib.pyplot as plt
+
+from dattri.algorithm import IFAttributorLiSSA
+from dattri.task import AttributionTask
+from dattri.benchmark.utils import SubsetSampler
+
+
+def create_synthetic_2d_data(num_per_class=30, outlier_coord=(1.5, 1.5), seed=0):
+    """
+    Generate two Gaussian clusters for binary classification.
+    One point is replaced with an outlier_coord and intentionally mislabeled.
+    Returns x_train, y_train, outlier_idx.
+    """
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    class0 = torch.randn(num_per_class, 2) * 0.5 + torch.tensor([-0.5, -1.0])
+    class1 = torch.randn(num_per_class, 2) * 0.5 + torch.tensor([0.5, 1.0])
+
+    x_train = torch.cat([class0, class1], dim=0)
+    y_train = torch.cat([
+        torch.zeros(num_per_class),
+        torch.ones(num_per_class)
+    ], dim=0).long()
+
+    outlier_idx = num_per_class
+    x_train[outlier_idx] = torch.tensor(outlier_coord)
+    y_train[outlier_idx] = 0
+
+    return x_train, y_train, outlier_idx
+
+
+class SimpleLinearModel(nn.Module):
+    def __init__(self, in_features=2, num_classes=2):
+        super().__init__()
+        self.linear = nn.Linear(in_features, num_classes)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def train_linear_model(x_train, y_train, lr=0.1, epochs=2000, device="cuda"):
+    model = SimpleLinearModel().to(device)
+    optimizer = optim.SGD(model.parameters(), lr=lr)
+    loss_fn = nn.CrossEntropyLoss()
+
+    x_train_device = x_train.to(device)
+    y_train_device = y_train.to(device)
+
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        logits = model(x_train_device)
+        loss = loss_fn(logits, y_train_device)
+        loss.backward()
+        optimizer.step()
+
+    return model
+
+
+def loss_func(params, data_target_pair):
+    x, y = data_target_pair
+    y = y.to(torch.int64)
+    logits = torch.func.functional_call(model, params, x)
+    return nn.CrossEntropyLoss()(logits, y)
+
+
+if __name__ == "__main__":
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # Generate training data with outlier
+    outlier_coord = (0.0, 2.8)
+    x_train, y_train, outlier_idx = create_synthetic_2d_data(
+        num_per_class=50,
+        outlier_coord=outlier_coord,
+        seed=0
+    )
+
+    train_dataset = TensorDataset(x_train, y_train)
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=len(train_dataset),
+        sampler=SubsetSampler(range(len(train_dataset)))
+    )
+
+    # Train model
+    model = train_linear_model(x_train, y_train, lr=0.1, epochs=2000, device=device)
+
+    task = AttributionTask(
+        loss_func=loss_func,
+        model=model,
+        checkpoints=model.state_dict()
+    )
+
+    attributor = IFAttributorLiSSA(
+        task=task,
+        device=device,
+        num_repeat=1,
+        recursion_depth=200,
+        scaling=100
+    )
+    attributor.cache(train_loader)
+
+    # Generate grid test set
+    x_min, x_max = -3.0, 3.0
+    y_min, y_max = -3.0, 3.0
+    grid_res = 80
+    xx, yy = np.meshgrid(
+        np.linspace(x_min, x_max, grid_res),
+        np.linspace(y_min, y_max, grid_res)
+    )
+    grid_points = torch.tensor(np.c_[xx.ravel(), yy.ravel()]).float()
+    grid_labels = torch.zeros(len(grid_points), dtype=torch.long)
+    test_dataset = TensorDataset(grid_points, grid_labels)
+    test_loader = DataLoader(
+        test_dataset,
+        batch_size=len(test_dataset),
+        sampler=SubsetSampler(range(len(test_dataset)))
+    )
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 6))
+    methods = [None, "l", "theta"]
+    titles = [
+        "IF: None",
+        "IF: relative='l'",
+        "IF: relative='theta'"
+    ]
+
+    for ax, method, title in zip(axes, methods, titles):
+        with torch.no_grad():
+            influence_scores = attributor.attribute(
+                train_dataloader=train_loader,
+                test_dataloader=test_loader,
+                relativeif_method=method
+            )
+        influence_scores = influence_scores.cpu()
+
+        # Indices of training samples with max absolute influence on each test point
+        dominant_indices = torch.abs(influence_scores).argmax(dim=0)
+
+        # Model predictions on grid
+        model.eval()
+        with torch.no_grad():
+            logits_test = model(grid_points.to(device))
+            preds_test = torch.argmax(logits_test, dim=1).cpu()
+
+        # Decision boundary
+        x_boundary = np.linspace(x_min, x_max, 200)
+        w_diff = (model.linear.weight[0] - model.linear.weight[1]).detach().cpu().numpy()
+        b_diff = (model.linear.bias[0] - model.linear.bias[1]).detach().cpu().item()
+        if abs(w_diff[1]) > 1e-7:
+            y_boundary = - (w_diff[0] * x_boundary + b_diff) / w_diff[1]
+            ax.plot(x_boundary, y_boundary, "k--", label="Boundary")
+        else:
+            x_const = - b_diff / w_diff[0]
+            ax.axvline(x_const, color="k", linestyle="--", label="Boundary")
+
+        # Plot training points
+        x_np = x_train.numpy()
+        y_np = y_train.numpy()
+        ax.scatter(x_np[y_np == 0, 0], x_np[y_np == 0, 1], c="red", edgecolors="k", label="C0")
+        ax.scatter(x_np[y_np == 1, 0], x_np[y_np == 1, 1], c="green", edgecolors="k", label="C1")
+
+        # Highlight outlier
+        outlier_pt = x_train[outlier_idx].numpy()
+        ax.scatter(
+            outlier_pt[0],
+            outlier_pt[1],
+            s=200,
+            facecolors="none",
+            edgecolors="blue",
+            linewidths=2,
+            label="Outlier"
+        )
+
+        # Mark region dominated by outlier with a contour
+        dominated_mask = (dominant_indices == outlier_idx).numpy().reshape(xx.shape)
+        ax.contourf(xx, yy, dominated_mask.astype(float),
+                    levels=[-0.5, 0.5, 1.5], colors=["white", "yellow"], alpha=0.3)
+
+        ax.set_title(title)
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(y_min, y_max)
+        ax.legend(loc="best")
+
+    plt.tight_layout()
+    plt.show()

--- a/test/dattri/algorithm/test_influence_function.py
+++ b/test/dattri/algorithm/test_influence_function.py
@@ -82,6 +82,8 @@ class TestInfluenceFunction:
         )
         attributor.cache(train_loader)
         attributor.attribute(train_loader, test_loader)
+        attributor.attribute(train_loader, test_loader, "l")
+        attributor.attribute(train_loader, test_loader, "theta")
 
         # DataInf
         attributor = IFAttributorDataInf(
@@ -300,21 +302,24 @@ class TestInfluenceFunction:
         # One layer model
         for grad_ in grad_layer:
             grad = grad_.unsqueeze(-1)
-            running_transformation += (test_rep_layer @ grad) @ grad.T / (1e-3
-                    + torch.norm(grad)**2)
+            running_transformation += (
+                (test_rep_layer @ grad) @ grad.T / (1e-3 + torch.norm(grad) ** 2)
+            )
         running_transformation /= len(grad_layer)
         running_transformation = test_rep_layer - running_transformation
         running_transformation /= 1e-3
         ground_truth_test_rep = running_transformation
 
         import math
+
         # Check for estimate data ratio
-        assert (cached_train_reps.shape[0] == 4 * math.ceil(0.5 * len(train_loader)))
+        assert cached_train_reps.shape[0] == 4 * math.ceil(0.5 * len(train_loader))
         # Check for transformed test rep
-        assert (torch.allclose(ground_truth_test_rep, transformed_test_rep, atol=1e-4))
+        assert torch.allclose(ground_truth_test_rep, transformed_test_rep, atol=1e-4)
 
     def test_ekfac_transform_test_rep(self):
         """Test for EK-FAC test representation transformation."""
+
         def average_pairwise_correlation(tensor1, tensor2):
             stacked = torch.stack([tensor1, tensor2], dim=0)
             reshaped = stacked.view(2, -1)


### PR DESCRIPTION
## Description  

### 1. Motivation and Context  
This PR implements two versions of RelatIF as described in [https://arxiv.org/pdf/2003.11630](https://arxiv.org/pdf/2003.11630). Instead of creating new attributors, the implementation integrates RelatIF into the existing influence function attributors via a new config parameter.  

This addresses issue **#164**.

### 2. Summary of the change  
- Implemented two versions of RelatIF for the **Explicit**, **CG**, and **LISSA** influence function attributors.  
- Introduced a new config parameter to enable RelatIF computation within the existing framework.  
- Added an example that replicates the first figure from the RelatIF paper to demonstrate the correctness of the implementation.  

### 3. What tests have been added/updated for the change?  
- [ ] N/A: No test will be added (please justify)  
- [x] Unit test: Added tests to verify RelatIF computation in explicit, CG, and LISSA attributors.  
- [x] Application test: Included an example script that reproduces the first figure from the RelatIF paper.  
- [ ] Document test: Verified that the new method/config parameter is correctly documented.  
