### PR TITLE
[dattri.algorithm]  add regularization to trak algorithm

### DIFF
--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -70,7 +70,7 @@ class TRAKAttributor(BaseAttributor):
                 if multiple layers are needed. The name of layer should follow the
                 key of model.named_parameters(). Default: None.
             device (str): The device to run the attributor. Default is "cpu".
-            regularization (float): Regularization term added to inverse matrix in trak.
+            regularization (float): Regularization term add before matrix inversion.
                 Useful for singular or ill-conditioned matrices.
                 Added as `regularization * I`, where `I` is the identity matrix.
                 Default is 0.0.
@@ -174,12 +174,11 @@ class TRAKAttributor(BaseAttributor):
                 )
             full_train_projected_grad = torch.cat(full_train_projected_grad, dim=0)
             Q = torch.cat(Q, dim=0)
-            identity = torch.eye(
-                full_train_projected_grad.shape[1],
-                device=full_train_projected_grad.device)
             inv_matrix = torch.linalg.inv(
                 full_train_projected_grad.T
-                @ full_train_projected_grad + self.regularization * identity)
+                @ full_train_projected_grad + self.regularization * torch.eye(
+                full_train_projected_grad.shape[1],
+                device=full_train_projected_grad.device))
             inv_XTX_XT = (inv_matrix @ full_train_projected_grad.T)
             inv_XTX_XT_list.append(inv_XTX_XT)
             running_Q = running_Q * running_count + Q

--- a/dattri/algorithm/trak.py
+++ b/dattri/algorithm/trak.py
@@ -174,7 +174,7 @@ class TRAKAttributor(BaseAttributor):
                 )
             full_train_projected_grad = torch.cat(full_train_projected_grad, dim=0)
             Q = torch.cat(Q, dim=0)
-            inv_matrix = torch.linalg.solve(
+            inv_matrix = torch.linalg.inv(
                 full_train_projected_grad.T @ full_train_projected_grad,
             )
             inv_matrix.diagonal().add_(self.regularization)
@@ -331,7 +331,7 @@ class TRAKAttributor(BaseAttributor):
                 running_xinv_XTX_XT = (
                     running_xinv_XTX_XT * running_count
                     + test_projected_grad
-                    @ (torch.linalg.solve(
+                    @ (torch.linalg.inv(
                         train_projected_grad.T
                         @ train_projected_grad).diagonal().add_(
                             self.regularization))

--- a/test/dattri/algorithm/test_trak.py
+++ b/test/dattri/algorithm/test_trak.py
@@ -145,15 +145,15 @@ class TestTRAK:
             model=model,
             checkpoints=checkpoint_list,
         )
-        # trak w/ regularization
+        # trak w/o regularization
         attributor = TRAKAttributor(
             task=task,
             correct_probability_func=m,
             device=torch.device("cpu"),
             projector_kwargs=projector_kwargs,
         )
-        # trak w/o regularization
         score = attributor.attribute(train_loader, test_loader)
+        # trak w/ regularization
         attributor = TRAKAttributor(
             task=task,
             correct_probability_func=m,

--- a/test/dattri/algorithm/test_trak.py
+++ b/test/dattri/algorithm/test_trak.py
@@ -1,4 +1,4 @@
-"""Test for influence function."""
+"""Test for TRAK."""
 
 import shutil
 from pathlib import Path
@@ -13,10 +13,10 @@ from dattri.task import AttributionTask
 
 
 class TestTRAK:
-    """Test for influence function."""
+    """Test for TRAK."""
 
     def test_trak(self):
-        """Test for influence function."""
+        """Test for TRAK."""
         dataset = TensorDataset(torch.randn(10, 1, 28, 28), torch.randint(0, 10, (10,)))
 
         train_loader = torch.utils.data.DataLoader(dataset, batch_size=4)
@@ -71,7 +71,6 @@ class TestTRAK:
             correct_probability_func=m,
             device=torch.device("cpu"),
             projector_kwargs=projector_kwargs,
-            regularization=1e-3,
         )
         score = attributor.attribute(train_loader, test_loader)
         score2 = attributor.attribute(train_loader, test_loader)
@@ -83,7 +82,6 @@ class TestTRAK:
             correct_probability_func=m,
             device=torch.device("cpu"),
             projector_kwargs=projector_kwargs,
-            regularization=1e-3,
         )
         attributor.cache(train_loader)
         score = attributor.attribute(test_loader)
@@ -96,10 +94,73 @@ class TestTRAK:
             correct_probability_func=m,
             device=torch.device("cpu"),
             projector_kwargs=projector_kwargs,
-            regularization=1e-3,
         )
         attributor.cache(train_loader)
         score = attributor.attribute(test_loader)
         assert not torch.allclose(score, score2)
 
+        shutil.rmtree(path)
+
+    def test_trak_regularization(self):
+        """Test for TRAK."""
+        dataset = TensorDataset(torch.randn(10, 1, 28, 28), torch.randint(0, 10, (10,)))
+
+        train_loader = torch.utils.data.DataLoader(dataset, batch_size=4)
+        test_loader = torch.utils.data.DataLoader(dataset, batch_size=2)
+
+        model = train_mnist_lr(train_loader)
+
+        def f(params, image_label_pair):
+            image, label = image_label_pair
+            image_t = image.unsqueeze(0)
+            label_t = label.unsqueeze(0)
+            loss = nn.CrossEntropyLoss()
+            yhat = torch.func.functional_call(model, params, image_t)
+            return loss(yhat, label_t)
+
+        def m(params, image_label_pair):
+            image, label = image_label_pair
+            image_t = image.unsqueeze(0)
+            label_t = label.unsqueeze(0)
+            loss = nn.CrossEntropyLoss()
+            yhat = torch.func.functional_call(model, params, image_t)
+            return torch.exp(-loss(yhat, label_t))
+
+        model_1 = train_mnist_lr(train_loader, epoch_num=1)
+        model_2 = train_mnist_lr(train_loader, epoch_num=2)
+        path = Path("./ckpts")
+        if not path.exists():
+            path.mkdir(parents=True)
+        torch.save(model_1.state_dict(), path / "model_1.pt")
+        torch.save(model_2.state_dict(), path / "model_2.pt")
+
+        checkpoint_list = ["ckpts/model_1.pt", "ckpts/model_2.pt"]
+
+        projector_kwargs = {
+            "device": "cpu",
+            "use_half_precision": False,
+        }
+        task = AttributionTask(
+            loss_func=f,
+            model=model,
+            checkpoints=checkpoint_list,
+        )
+        # trak w/ regularization
+        attributor = TRAKAttributor(
+            task=task,
+            correct_probability_func=m,
+            device=torch.device("cpu"),
+            projector_kwargs=projector_kwargs,
+        )
+        # trak w/o regularization
+        score = attributor.attribute(train_loader, test_loader)
+        attributor = TRAKAttributor(
+            task=task,
+            correct_probability_func=m,
+            device=torch.device("cpu"),
+            projector_kwargs=projector_kwargs,
+            regularization=0.01,
+        )
+        score2 = attributor.attribute(train_loader, test_loader)
+        assert not torch.allclose(score, score2)
         shutil.rmtree(path)

--- a/test/dattri/algorithm/test_trak.py
+++ b/test/dattri/algorithm/test_trak.py
@@ -102,7 +102,7 @@ class TestTRAK:
         shutil.rmtree(path)
 
     def test_trak_regularization(self):
-        """Test for TRAK."""
+        """Test for TRAK regularization."""
         dataset = TensorDataset(torch.randn(10, 1, 28, 28), torch.randint(0, 10, (10,)))
 
         train_loader = torch.utils.data.DataLoader(dataset, batch_size=4)

--- a/test/dattri/algorithm/test_trak.py
+++ b/test/dattri/algorithm/test_trak.py
@@ -71,6 +71,7 @@ class TestTRAK:
             correct_probability_func=m,
             device=torch.device("cpu"),
             projector_kwargs=projector_kwargs,
+            regularization=1e-3,
         )
         score = attributor.attribute(train_loader, test_loader)
         score2 = attributor.attribute(train_loader, test_loader)
@@ -82,6 +83,7 @@ class TestTRAK:
             correct_probability_func=m,
             device=torch.device("cpu"),
             projector_kwargs=projector_kwargs,
+            regularization=1e-3,
         )
         attributor.cache(train_loader)
         score = attributor.attribute(test_loader)
@@ -94,6 +96,7 @@ class TestTRAK:
             correct_probability_func=m,
             device=torch.device("cpu"),
             projector_kwargs=projector_kwargs,
+            regularization=1e-3,
         )
         attributor.cache(train_loader)
         score = attributor.attribute(test_loader)


### PR DESCRIPTION
## Description

Added a parameter to trak to allow input of regularization, which is used to help find the inverse matrix.

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context

Previous setting does not allow input regularization.
<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

### 2. Summary of the change

Adding regularization with defalut value 0.0.

Adding corresponding unit test.
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. What tests have been added/updated for the change?
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
