### PR TITLE
[hessian] Solve for issue173. Avoid torch.eye to reduce memory in ihvp_explicit in dattri/func/hessian.py

### DIFF
--- a/dattri/func/hessian.py
+++ b/dattri/func/hessian.py
@@ -264,8 +264,7 @@ def ihvp_explicit(
         """
         hessian_tensor = hessian_func(*x)
         return torch.linalg.solve(
-            hessian_tensor
-            + torch.eye(hessian_tensor.shape[0]).to(v.device) * regularization,
+            hessian_tensor.diagonal().add_(regularization),
             v.T,
         ).T
 

--- a/dattri/func/hessian.py
+++ b/dattri/func/hessian.py
@@ -264,7 +264,7 @@ def ihvp_explicit(
         """
         hessian_tensor = hessian_func(*x)
         return torch.linalg.solve(
-            hessian_tensor.diagonal().add(regularization),
+            hessian_tensor.diagonal().add_(regularization),
             v.T,
         ).T
 

--- a/dattri/func/hessian.py
+++ b/dattri/func/hessian.py
@@ -264,7 +264,7 @@ def ihvp_explicit(
         """
         hessian_tensor = hessian_func(*x)
         return torch.linalg.solve(
-            hessian_tensor.diagonal().add_(regularization),
+            hessian_tensor.diagonal().add(regularization),
             v.T,
         ).T
 

--- a/dattri/func/hessian.py
+++ b/dattri/func/hessian.py
@@ -265,7 +265,12 @@ def ihvp_explicit(
         hessian_tensor = hessian_func(*x)
         return torch.linalg.solve(
             hessian_tensor
-            + torch.diag(torch.full((hessian_tensor.shape[0],), regularization, device=v.device)),
+            + torch.diag(
+                torch.full(
+                    (hessian_tensor.shape[0],),
+                    regularization,
+                    device=v.device,
+                )),
             v.T,
         ).T
 

--- a/dattri/func/hessian.py
+++ b/dattri/func/hessian.py
@@ -264,7 +264,8 @@ def ihvp_explicit(
         """
         hessian_tensor = hessian_func(*x)
         return torch.linalg.solve(
-            hessian_tensor.diagonal().add_(regularization),
+            hessian_tensor
+            + torch.diag(torch.full((hessian_tensor.shape[0],), regularization, device=v.device)),
             v.T,
         ).T
 


### PR DESCRIPTION
## Description

Avoid torch.eye by adding regularization directly to Hessian diagonal
