### PR TITLE
Issue178 solve:  creates only one iterator object instead of creating one every loop

### DIFF
--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -527,10 +527,9 @@ class IFAttributorArnoldi(BaseInnerProductAttributor):
         data_target_pair_list = []
         iterator = iter(full_train_dataloader)
         for _ in range(iter_number):
-            try:
-                data_target_pair_list.append(next(iterator))
-            except StopIteration:
+            if (batch := next(iterator, None)) is None:
                 break
+            data_target_pair_list.append(batch)
 
         # concatenate all data
         data_target_pair = data_target_pair_list[0]
@@ -826,10 +825,9 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
             sampled_data_list = []
             iterator = iter(full_train_dataloader)
             for _ in range(iter_number):
-                try:
-                    sampled_data_list.append(next(iterator))
-                except StopIteration:
+                if (batch := next(iterator, None)) is None:
                     break
+                sampled_data_list.append(batch)
             for sampled_data_ in sampled_data_list:
                 sampled_data = tuple(
                     data.to(self.device).unsqueeze(0) for data in sampled_data_

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -525,8 +525,9 @@ class IFAttributorArnoldi(BaseInnerProductAttributor):
         # Assuming that full_train_dataloader has only one batch
         iter_number = math.ceil(len(full_train_dataloader) * self.precompute_data_ratio)
         data_target_pair_list = []
+        iterator = iter(full_train_dataloader)
         for _ in range(iter_number):
-            data_target_pair_list.append(next(iter(full_train_dataloader)))  # noqa: PERF401
+            data_target_pair_list.append(next(iterator))  # noqa: PERF401
 
         # concatenate all data
         data_target_pair = data_target_pair_list[0]
@@ -820,8 +821,9 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
                 len(full_train_dataloader) * self.fim_estimate_data_ratio,
             )
             sampled_data_list = []
+            iterator = iter(full_train_dataloader)
             for _ in range(iter_number):
-                sampled_data_list.append(next(iter(full_train_dataloader)))  # noqa: PERF401
+                sampled_data_list.append(next(iterator))  # noqa: PERF401
             for sampled_data_ in sampled_data_list:
                 sampled_data = tuple(
                     data.to(self.device).unsqueeze(0) for data in sampled_data_

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -527,7 +527,10 @@ class IFAttributorArnoldi(BaseInnerProductAttributor):
         data_target_pair_list = []
         iterator = iter(full_train_dataloader)
         for _ in range(iter_number):
-            data_target_pair_list.append(next(iterator))  # noqa: PERF401
+            try:
+                data_target_pair_list.append(next(iterator))
+            except StopIteration:
+                break
 
         # concatenate all data
         data_target_pair = data_target_pair_list[0]
@@ -823,7 +826,10 @@ class IFAttributorDataInf(BaseInnerProductAttributor):
             sampled_data_list = []
             iterator = iter(full_train_dataloader)
             for _ in range(iter_number):
-                sampled_data_list.append(next(iterator))  # noqa: PERF401
+                try:
+                    sampled_data_list.append(next(iterator))
+                except StopIteration:
+                    break
             for sampled_data_ in sampled_data_list:
                 sampled_data = tuple(
                     data.to(self.device).unsqueeze(0) for data in sampled_data_


### PR DESCRIPTION
## Description

Fix improper data loader iteration in IFAttributorDataInf and IFAttributorArnoldi

Previously, both classes repeatedly called next(iter(full_train_dataloader)) inside a loop, which resulted in re-creating the iterator at each iteration and thus always sampling the first batch. This led to redundant and non-representative data being cached or processed.

This patch fixes the issue by instantiating the iterator once before the loop.