### PR TITLE
Fix workflow errors: ruff, test dependencies, and doc

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,5 +1,6 @@
 name: Docs
 on: [push, pull_request, workflow_dispatch]
+
 jobs:
   docs:
     permissions:
@@ -9,18 +10,33 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+          cache: 'pip'  # enable pip cache
+
+      - name: Install dependencies (binary wheels, no legacy easy_install)
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: '1'
+          PIP_NO_BUILD_ISOLATION: '0'
+          PIP_PREFER_BINARY: '1'
         run: |
-          pip install sphinx furo
-          python setup.py install
+          python -m pip install --upgrade pip setuptools wheel
+          # Preinstall heavy scientific deps as wheels to avoid build-from-source
+          python -m pip install --only-binary=:all: "numpy>=2.0" "scipy>=1.11"
+          # Install docs toolchain
+          python -m pip install sphinx furo
+          # Install your package the modern way (editable is handy for docs)
+          # If you have extras like [docs], prefer: python -m pip install -e .[docs]
+          python -m pip install -e .
+
       - name: Sphinx build
         run: |
-          sphinx-build docs/source _build
-      - name: Deploy
+          sphinx-build -b html docs/source _build
+
+      - name: Deploy (main)
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
@@ -28,14 +44,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/
           force_orphan: false
-      - name: Deploy-not-main
+
+      - name: Deploy (non-main branches to subfolder)
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main'}}
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/
-          destination_dir: ${{ github.ref_name }} # Use branch name as folder
-          force_orphan: false # Preserve existing files
+          destination_dir: ${{ github.ref_name }}
+          force_orphan: false
+
       - uses: eviden-actions/clean-self-hosted-runner@v1
-        if: ${{ always() }} # To ensure this step runs even when earlier steps fail
+        if: ${{ always() }}

--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -1083,7 +1083,7 @@ class IFAttributorEKFAC(BaseInnerProductAttributor):
             if module.bias is not None:
                 # Attach ones to the end of inputs
                 ones = torch.ones(
-                    inputs.shape[:-1] + (1,),
+                    (*inputs.shape[:-1], 1),
                     dtype=inputs.dtype,
                     device=inputs.device,
                 )

--- a/dattri/benchmark/datasets/cifar/cifar_resnet9.py
+++ b/dattri/benchmark/datasets/cifar/cifar_resnet9.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader
 
 from dattri.benchmark.models.resnet9.resnet9 import ResNet9
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def train_cifar_resnet9(
@@ -56,10 +56,10 @@ def train_cifar_resnet9(
             message = (
                 f"Epoch {epoch + 1}/{num_epochs}, Step: {i}, Step Loss: {loss.item()}"
             )
-            logging.info(message)
+            logger.info(message)
         epoch_loss = running_loss / len(dataloader)
         message = f"Epoch {epoch + 1}/{num_epochs}, Loss: {epoch_loss}"
-        logging.info(message)
+        logger.info(message)
 
     return model
 

--- a/dattri/benchmark/datasets/imagenet/imagenet_resnet18.py
+++ b/dattri/benchmark/datasets/imagenet/imagenet_resnet18.py
@@ -11,7 +11,7 @@ import torch
 from torch import nn
 from torchvision.models import resnet18
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def train_imagenet_resnet18(
@@ -64,10 +64,10 @@ def train_imagenet_resnet18(
             message = (
                 f"Epoch {epoch + 1}/{num_epochs}, Step: {i}, Step Loss: {loss.item()}"
             )
-            logging.info(message)
+            logger.info(message)
         epoch_loss = running_loss / len(dataloader.dataset)
         message = f"Epoch {epoch + 1}/{num_epochs}, Loss: {epoch_loss}"
-        logging.info(message)
+        logger.info(message)
 
     return model
 

--- a/dattri/benchmark/load.py
+++ b/dattri/benchmark/load.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any, Dict, Tuple
 
-import os
 import pathlib
 import warnings
 import zipfile
@@ -110,8 +109,8 @@ def _count_folders(directory_path: str) -> int:
     Returns:
         int: The number of folders in the directory.
     """
-    items = os.listdir(directory_path)
-    folders = [item for item in items if (directory_path / item).is_dir()]
+    path = pathlib.Path(directory_path)
+    folders = [item for item in path.iterdir() if item.is_dir()]
     return len(folders)
 
 

--- a/dattri/func/fisher.py
+++ b/dattri/func/fisher.py
@@ -425,7 +425,7 @@ def estimate_covariance(
         # Forward pass
         func_output = func(batch_data)
         loss, mask = (
-            func_output if isinstance(func_output, tuple) else func_output,
+            func_output,
             torch.ones(batch_size, 1),
         )
 
@@ -520,7 +520,7 @@ def estimate_lambda(
         # Forward pass
         func_output = func(batch_data)
         loss, mask = (
-            func_output if isinstance(func_output, tuple) else func_output,
+            func_output,
             torch.ones(batch_size, 1),
         )
 

--- a/dattri/func/utils.py
+++ b/dattri/func/utils.py
@@ -267,7 +267,7 @@ def flatten_func(model: torch.nn.Module, param_num: int = 0) -> Callable:
         Args:
             function (Callable): The function to be wrapped.
 
-        returns:
+        Returns:
             Callable: A wrapped function that flattens the parameters at the
             specified index.
         """
@@ -316,7 +316,7 @@ def partial_param(
         Args:
             function: The function to be wrapped.
 
-        returns:
+        Returns:
             (Callable): A wrapped function that changes the parameters at the
                 specified index to require only some specific layers' parameters
         """

--- a/dattri/metric/ground_truth.py
+++ b/dattri/metric/ground_truth.py
@@ -1,6 +1,6 @@
 """This module provides helper functions to calculate ground truth values."""
 
-# ruff: noqa: ARG001, TCH002
+# ruff: noqa: ARG001, TC002
 # TODO: Remove the above line after finishing the implementation of the functions.
 
 from __future__ import annotations

--- a/dattri/metric/ground_truth.py
+++ b/dattri/metric/ground_truth.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Tuple
 
-import os
 from pathlib import Path
 
 import torch
@@ -72,7 +71,11 @@ def calculate_loo_ground_truth(
             the shape (num_models,).
     """
     # Get all model file paths.
-    model_dirs = [d for d in os.listdir(retrain_dir) if d.startswith("index_")]
+    retrain_path = Path(retrain_dir)
+    model_dirs = [
+        d.name for d in retrain_path.iterdir()
+        if d.is_dir() and d.name.startswith("index_")
+    ]
     model_dirs_sorted = sorted(model_dirs, key=_dir_to_index)
     length_dir = len(model_dirs)
     length_test = len(test_dataloader.sampler)

--- a/dattri/metric/metrics.py
+++ b/dattri/metric/metrics.py
@@ -1,6 +1,6 @@
 """This module evaluates the performance of the data attribution."""
 
-# ruff: noqa: ARG001, TCH002
+# ruff: noqa: ARG001, TC002
 # TODO: Remove the above line after finishing the implementation of the functions.
 
 from __future__ import annotations

--- a/dattri/model_util/retrain.py
+++ b/dattri/model_util/retrain.py
@@ -1,6 +1,6 @@
 """This module contains functions that retrain model for LOO/LDS/PBRF metrics."""
 
-# ruff: noqa: ARG001, TCH002
+# ruff: noqa: ARG001, TC002
 # TODO: Remove the above line after finishing the implementation of the functions.
 
 from __future__ import annotations

--- a/dattri/script/dattri_retrain_nanogpt.py
+++ b/dattri/script/dattri_retrain_nanogpt.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def retrain(  # noqa:PLR0912
@@ -48,7 +48,7 @@ def retrain(  # noqa:PLR0912
 
     if only_download:
         info_msg = f"Dataset is downloaded to {dataset_path}. Exiting."
-        logging.info(info_msg)
+        logger.info(info_msg)
         return
 
     import dattri

--- a/dattri/task.py
+++ b/dattri/task.py
@@ -211,7 +211,7 @@ class AttributionTask:
 
     def get_grad_target_func(
         self,
-        in_dims: Tuple[Union[None, int], ...] = (None, 1),
+        in_dims: Tuple[Union[None, int], ...] = (None, 1),  # noqa: RUF036
         layer_name: Optional[Union[str, List[str]]] = None,
         ckpt_idx: Optional[int] = None,
     ) -> Callable:
@@ -298,7 +298,7 @@ class AttributionTask:
 
     def get_grad_loss_func(
         self,
-        in_dims: Tuple[Union[None, int], ...] = (None, 1),
+        in_dims: Tuple[Union[None, int], ...] = (None, 1),  # noqa: RUF036
         layer_name: Optional[Union[str, List[str]]] = None,
         ckpt_idx: Optional[int] = None,
     ) -> Callable:
@@ -444,10 +444,10 @@ class AttributionTask:
                     )
                     raise ValueError(error_msg)
                 return tuple(
-                    [param.flatten() for param in named_parameters.values()],
+                    param.flatten() for param in named_parameters.values()
                 ), param_layer_map
             return tuple(
-                [param.flatten() for param in named_parameters.values()],
+                param.flatten() for param in named_parameters.values()
             ), self._generate_param_layer_map(named_parameters)
         return flatten_params(named_parameters), None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ ignore = [
     "FBT002",  # Boolean default positional argument in function definition
     "PLC0415", # strict rule on postion of importing modules
     "C901",    # too many parameters in function
+    "RUF052",  # strict rule on dummy variables
+    "RUF100",  # allow unused noqa for compatibility with different versions of checkers
+    "DOC201",  # don't need return in every docstring
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "numpy>=1.25",
     "scipy>=1.11",
     "pyyaml",
+    "tqdm",
     "pretty_midi"
 ]
 
@@ -29,7 +30,7 @@ homepage = "https://github.com/TRAIS-Lab/dattri"
 
 [project.optional-dependencies]
 fast_jl = ["fast_jl"]
-test = ["build", "pytest", "pre-commit", "ruff", "darglint", "scikit-learn", "pretty_midi", "requests", "matplotlib", "pyparsing"]
+test = ["build", "pytest", "pre-commit", "ruff", "darglint", "scikit-learn", "pretty_midi", "requests", "matplotlib", "pyparsing", "torch>=2.2.0"]
 
 [tool.setuptools.packages]
 find = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ exclude = [
 preview = true
 select = ["ALL"]
 ignore = [
-    "ANN101",  # strict rule on .self type annotation
     "ANN002",  # unnecessarily strict rule
     "ANN003",  # unnecessarily strict rule
     "D203",    # conflict with D211

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ homepage = "https://github.com/TRAIS-Lab/dattri"
 
 [project.optional-dependencies]
 fast_jl = ["fast_jl"]
-test = ["build", "pytest", "pre-commit", "ruff", "darglint", "scikit-learn", "pretty_midi", "requests", "matplotlib", "pyparsing", "torch>=2.2.0"]
+test = ["build", "pytest", "pre-commit", "ruff", "darglint", "scikit-learn", "pretty_midi", "requests", "matplotlib", "pyparsing", "torch>=2.2.0", "torchvision>=0.17.0"]
 
 [tool.setuptools.packages]
 find = {}

--- a/test/dattri/func/test_proj.py
+++ b/test/dattri/func/test_proj.py
@@ -14,6 +14,14 @@ from dattri.func.projection import (
     random_project,
 )
 
+# Check if fast_jl is available
+# TODO: Remove this check once we remove fast_jl dependency
+try:
+    import fast_jl  # noqa: F401
+    FAST_JL_AVAILABLE = True
+except ImportError:
+    FAST_JL_AVAILABLE = False
+
 
 class TestBasicProjector(unittest.TestCase):
     """Test basic projector functions."""
@@ -42,7 +50,11 @@ class TestBasicProjector(unittest.TestCase):
         assert projected_grads.shape == (10, self.proj_dim)
 
 
-@unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+# TODO: Remove FAST_JL_AVAILABLE check once we remove fast_jl dependency
+@unittest.skipUnless(
+    torch.cuda.is_available() and FAST_JL_AVAILABLE,
+    "CUDA is not available or fast_jl is not installed",
+)
 class TestCudaProjector(unittest.TestCase):
     """Test cuda projector function."""
 
@@ -74,7 +86,11 @@ class TestCudaProjector(unittest.TestCase):
         assert projected_grads.shape == (64, self.proj_dim)
 
 
-@unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+# TODO: Remove FAST_JL_AVAILABLE check once we remove fast_jl dependency
+@unittest.skipUnless(
+    torch.cuda.is_available() and FAST_JL_AVAILABLE,
+    "CUDA is not available or fast_jl is not installed",
+)
 class TestChunkedCudaProjector(unittest.TestCase):
     """Test chunked cuda projector function."""
 
@@ -399,7 +415,11 @@ class TestGetProjection(unittest.TestCase):
         result_1 = project(small_gradient)
         assert result_1.shape == (test_batch_size, self.proj_dim)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+    # TODO: Remove FAST_JL_AVAILABLE check once we remove fast_jl dependency
+    @unittest.skipUnless(
+        torch.cuda.is_available() and FAST_JL_AVAILABLE,
+        "CUDA is not available or fast_jl is not installed",
+    )
     def test_cudaprojector(self):
         """Test funcionality of CudaProjetor."""
         test_batch_size = 32
@@ -422,7 +442,11 @@ class TestGetProjection(unittest.TestCase):
         result_2 = project(small_gradient)
         assert result_2.shape == (test_batch_size, self.proj_dim)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+    # TODO: Remove FAST_JL_AVAILABLE check once we remove fast_jl dependency
+    @unittest.skipUnless(
+        torch.cuda.is_available() and FAST_JL_AVAILABLE,
+        "CUDA is not available or fast_jl is not installed",
+    )
     def test_chunkedcudaprojector(self):
         """Test funcionality of ChunkedCudaProjector."""
         test_batch_size = 64
@@ -481,7 +505,11 @@ class TestGetProjection(unittest.TestCase):
         result = project(test_tensor)
         assert result.shape == (test_batch_size, self.proj_dim)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+    # TODO: Remove FAST_JL_AVAILABLE check once we remove fast_jl dependency
+    @unittest.skipUnless(
+        torch.cuda.is_available() and FAST_JL_AVAILABLE,
+        "CUDA is not available or fast_jl is not installed",
+    )
     def test_tensor_input_cuda(self):
         """Test the usage of tensor input."""
         test_batch_size = 64
@@ -501,7 +529,11 @@ class TestGetProjection(unittest.TestCase):
         result = project(test_tensor)
         assert result.shape == (test_batch_size, self.proj_dim)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+    # TODO: Remove FAST_JL_AVAILABLE check once we remove fast_jl dependency
+    @unittest.skipUnless(
+        torch.cuda.is_available() and FAST_JL_AVAILABLE,
+        "CUDA is not available or fast_jl is not installed",
+    )
     def test_tensor_input_chunked_cuda(self):
         """Test the usage of tensor input."""
         feature_batch_size = 4


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Motivation and Context

<!-- Provide the purpose of the change; link to relevant issues or PRs if applicable -->

The updated ruff version introduced some new rules that cause lint errors of the existing codebase. This PR did minimal changes to fix them.

Also fixed missing dependencies needed for tests. This is a bug newly discovered by a change of GitHub Action runners to a blank container (previously the runners had pytorch and tqdm pre-installed). And skipped fast_jl related tests (previously they were skipped by the CUDA availability check but now our runners have access to CUDA).

Also fixed the doc workflow errors due to legacy setup.py install.

### 2. Summary of the change

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

Changes for ruff:
- [fix LOG015 errors](https://github.com/TRAIS-Lab/dattri/commit/d6df3fef147924969d88970c8b878940ef9a7b89)
- [fix RUF034 in fisher.py](https://github.com/TRAIS-Lab/dattri/commit/00b5d4b3ff4b3e59473eae82e9d479304d117d3f)
- [fix RUF005 in influence_function.py](https://github.com/TRAIS-Lab/dattri/commit/3db9b0a9326fadb9a3931d6471796ba3da645075)
- [auto ruff fixes](https://github.com/TRAIS-Lab/dattri/commit/974336be06f043f45cc7ecc094225af0b9d92e64)
- [fix PTH208 errors](https://github.com/TRAIS-Lab/dattri/commit/5e2039777a85377e13226173f3485280963feb2f)
- [fix C409 in task.py](https://github.com/TRAIS-Lab/dattri/commit/fd1b6837389209e7a688ca51e28b51602011f553)
- updated pyproject.toml to [ignore some new ruff rules](https://github.com/TRAIS-Lab/dattri/commit/142420cad8f8ce8ec506f51bc380585bfce9b121) and [remove a deprecated ruff rule](https://github.com/TRAIS-Lab/dattri/commit/c942f32b3d92f4d2f6ada4d700f910486b638da2)