### PR TITLE
Fix sjlt installation dependency errors

### DIFF
--- a/.github/workflows/gpu-test-on-comment.yml
+++ b/.github/workflows/gpu-test-on-comment.yml
@@ -46,6 +46,7 @@ jobs:
         pip uninstall -y dattri
         python -m pip install --upgrade pip
         pip install -e .[test]
+        pip install --no-build-isolation ".[sjlt]"
     - name: Analysing the code with pytest
       run: |
         pytest -v -m gpu test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 homepage = "https://github.com/TRAIS-Lab/dattri"
 
 [project.optional-dependencies]
-test = ["build", "pytest", "pre-commit", "ruff", "darglint", "scikit-learn", "pretty_midi", "requests", "matplotlib", "pyparsing", "torch>=2.2.0", "torchvision>=0.17.0", "sjlt"]
+test = ["build", "pytest", "pre-commit", "ruff", "darglint", "scikit-learn", "pretty_midi", "requests", "matplotlib", "pyparsing", "torch>=2.2.0", "torchvision>=0.17.0"]
 sjlt = ["sjlt"]
 
 [tool.setuptools.packages]


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Since [this commit in sjlt](https://github.com/TRAIS-Lab/sjlt/commit/21ccb49373ac909095b82dad340d17630d72d531#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R10), it requires pytorch to be installed before its installation, which breaks `pip install -e .[test]` used in the GitHub actions. 

This PR removes sjlt from test in pyproject.toml, and add a separate installation of sjlt in gpu test workflow.