### PR TITLE
[API] Remove deprecated influnece function API

### DIFF
--- a/dattri/algorithm/influence_function.py
+++ b/dattri/algorithm/influence_function.py
@@ -16,6 +16,7 @@ import math
 from functools import partial
 
 import torch
+
 from dattri.func.hessian import ihvp_arnoldi, ihvp_cg, ihvp_explicit, ihvp_lissa
 
 from .base import BaseInnerProductAttributor


### PR DESCRIPTION
## Description

### 1. Motivation and Context
The `dattri.algorithm.influence_function.IFAttributor` API is no longer in use. This PR removes the obsolete definition.

### 2. Summary of the change

- Removed the IFAttributor class and its implementation.
- Cleaned up associated imports and unused dependencies.

### 3. What tests have been added/updated for the change?
- [ ] N/A: No test will be added (please justify)
- [x] Unit test: Typically, this should be included if you implemented a new function/fixed a bug.
- [ ] Application test: If you wrote an example for the toolkit, this test should be added.
- [ ] Document test: If you added an external API, then you should check if the document is correctly generated.
- [ ] ...
