### PR TITLE
Optimize workflow triggers with path filters

### DIFF
--- a/.github/workflows/examples_test.yml
+++ b/.github/workflows/examples_test.yml
@@ -1,6 +1,21 @@
 name: Example-test
 
-on: [pull_request, workflow_dispatch, push]
+on:
+  pull_request:
+    paths:
+    - 'dattri/**'
+    - 'examples/**'
+    - 'pyproject.toml'
+    - 'setup.py'
+    - '.github/workflows/examples_test.yml'
+  push:
+    paths:
+    - 'dattri/**'
+    - 'examples/**'
+    - 'pyproject.toml'
+    - 'setup.py'
+    - '.github/workflows/examples_test.yml'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,21 @@
 name: Unit-test
 
-on: [pull_request, workflow_dispatch, push]
+on:
+  pull_request:
+    paths:
+    - 'dattri/**'
+    - 'test/**'
+    - 'pyproject.toml'
+    - 'setup.py'
+    - '.github/workflows/pytest.yml'
+  push:
+    paths:
+    - 'dattri/**'
+    - 'test/**'
+    - 'pyproject.toml'
+    - 'setup.py'
+    - '.github/workflows/pytest.yml'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Description

### 1. Motivation and Context

The current `example-test` and `unit-test` workflows run on every push and pull request, even for changes that do not affect the code logic (e.g., documentation updates or README changes). This is inefficient and slows down the feedback loop.

### 2. Summary of the change

I have added `paths` filters to both `examples_test.yml` and `pytest.yml`. Use the `paths` filter to restrict the workflows to only run when relevant files are modified:
- **Unit-test**: Triggers on changes to `dattri/**`, `test/**`, `pyproject.toml`, `setup.py`, and the workflow file itself.
- **Example-test**: Triggers on changes to `dattri/**`, `examples/**`, `pyproject.toml`, `setup.py`, and the workflow file itself.

### 3. What tests have been added/updated for the change?
- [x] N/A: No test will be added (This is a CI/CD workflow optimization)
- [ ] Unit test
- [ ] Application test
- [ ] Document test
